### PR TITLE
Make sync confirmations best-effort so a failed send can't abort work

### DIFF
--- a/src/spanreed/apis/telegram_bot.py
+++ b/src/spanreed/apis/telegram_bot.py
@@ -19,6 +19,7 @@ from telegram import (
     constants,
     Message,
 )
+from telegram.error import TelegramError
 from telegram.ext import (
     ApplicationBuilder,
     AIORateLimiter,
@@ -530,6 +531,32 @@ class TelegramBotApi:
                     parse_mode=parse_mode,
                 ),
             )
+
+    async def notify(
+        self,
+        text: str,
+        *,
+        parse_html: bool = True,
+        parse_markdown: bool = False,
+    ) -> Message | None:
+        """Best-effort notification: deliver `text`, but never raise.
+
+        Use for fire-and-forget confirmations (e.g. "Logged X") where a
+        failed or rate-limited send must not abort the work that produced it,
+        nor crash the calling loop. Returns the sent Message, or None if
+        delivery failed.
+        """
+        try:
+            return await self.send_message(
+                text,
+                parse_html=parse_html,
+                parse_markdown=parse_markdown,
+            )
+        except (TelegramError, TimeoutError):
+            self._logger.warning(
+                f"Failed to deliver notification: {text!r}", exc_info=True
+            )
+            return None
 
     async def send_multiple_messages(
         self, *text: str, delay: int = 1, parse_html: bool = True

--- a/src/spanreed/plugins/hevy.py
+++ b/src/spanreed/plugins/hevy.py
@@ -104,9 +104,9 @@ class HevyPlugin(Plugin):
     async def _sync_now(self, user: User) -> None:
         """Manually triggered sync via the Telegram command."""
         bot: TelegramBotApi = await TelegramBotApi.for_user(user)
-        await bot.send_message("Checking Hevy for new workouts…")
+        await bot.notify("Checking Hevy for new workouts…")
         if await self._sync(user, bot) == 0:
-            await bot.send_message("No new Hevy workouts found.")
+            await bot.notify("No new Hevy workouts found.")
 
     async def _sync(self, user: User, bot: TelegramBotApi) -> int:
         """Fetch and write any new workouts. Returns the number written."""
@@ -134,7 +134,7 @@ class HevyPlugin(Plugin):
             set_count = await self._write_workout(config, webhook, workout)
             synced_ids.add(workout.id)
             await self._set_synced_ids(user, synced_ids)
-            await bot.send_message(
+            await bot.notify(
                 f"Logged Hevy workout: {workout.title} "
                 f"({set_count} sets across "
                 f"{len(workout.exercises)} exercises)."
@@ -167,7 +167,7 @@ class HevyPlugin(Plugin):
             try:
                 target = datetime.date.fromisoformat(date_str.strip())
             except ValueError:
-                await bot.send_message(
+                await bot.notify(
                     "That doesn't look like a YYYY-MM-DD date."
                 )
                 return
@@ -177,7 +177,7 @@ class HevyPlugin(Plugin):
                 if self._workout_date(w) == target
             ]
             if not workouts:
-                await bot.send_message(
+                await bot.notify(
                     f"No workout found on {target.isoformat()}."
                 )
                 return
@@ -189,7 +189,7 @@ class HevyPlugin(Plugin):
                 workouts = [await hevy.get_workout(workout_id)]
             except Exception:
                 self._logger.exception(f"Failed to fetch {workout_id=}")
-                await bot.send_message(
+                await bot.notify(
                     f"Couldn't fetch workout `{workout_id}`."
                 )
                 return
@@ -203,14 +203,14 @@ class HevyPlugin(Plugin):
                 return
             workouts = await hevy.get_all_workouts()
             if not workouts:
-                await bot.send_message("No workouts found.")
+                await bot.notify("No workouts found.")
                 return
         else:  # Cancel
             return
 
-        await bot.send_message(f"Re-creating {len(workouts)} workout(s)…")
+        await bot.notify(f"Re-creating {len(workouts)} workout(s)…")
         total_sets = await self._recreate(user, workouts)
-        await bot.send_message(
+        await bot.notify(
             f"Done. Wrote {total_sets} set notes across "
             f"{len(workouts)} workout(s)."
         )

--- a/src/spanreed/plugins/withings.py
+++ b/src/spanreed/plugins/withings.py
@@ -79,9 +79,9 @@ class WithingsPlugin(Plugin):
         else:  # Cancel
             return
 
-        await bot.send_message("Syncing Withings data…")
+        await bot.notify("Syncing Withings data…")
         if await self._sync(user, days=days) == 0:
-            await bot.send_message("No new Withings measurements found.")
+            await bot.notify("No new Withings measurements found.")
 
     async def _sync(self, user: User, *, days: int = 1) -> int:
         """Write measurements into the daily notes for the last ``days`` days.
@@ -120,13 +120,13 @@ class WithingsPlugin(Plugin):
                         daily_note, name, value
                     )
                 except FileNotFoundError:
-                    await bot.send_message(
+                    await bot.notify(
                         f"No daily note for {date.isoformat()}; skipping."
                     )
                     break
 
                 written += 1
-                await bot.send_message(
+                await bot.notify(
                     f"Logged {name} for {date.isoformat()}: {value}."
                 )
         return written


### PR DESCRIPTION
## What
Add `TelegramBotApi.notify()` — a best-effort send that logs and swallows delivery failures instead of raising — and route the fire-and-forget confirmations in the Withings and Hevy syncs through it.

## Why
A rate-limited or failed "Logged X" confirmation used to raise out of the sync loop, aborting the rest of the run *after* data had already been written (and, in a background loop, crashing the plugin). The data write should not depend on whether Telegram accepts a confirmation message.

## Changes
- `src/spanreed/apis/telegram_bot.py` — new `notify()`; catches `TelegramError` (incl. `RetryAfter`) and `TimeoutError`, logs, returns `None`.
- `src/spanreed/plugins/withings.py` — `_sync` / `_sync_now` confirmations use `notify()`.
- `src/spanreed/plugins/hevy.py` — `_sync` / `_sync_now` / `_recreate_data` confirmations use `notify()`.

## Deliberately unchanged
Interactive prompts (`request_user_choice` / `request_user_input`) and the Withings auth-link message still use `send_message`, where a delivery failure must surface rather than be swallowed.

## Notes
Completes the flood-control resilience series (after #9 rate limiter, #10 supervisor). The remaining follow-up we discussed — a durable outbound queue so startup/error notices survive an active ban — is intentionally out of scope here (item 4, to be designed separately).
