### PR TITLE
Add a durable outbound notification queue

### DIFF
--- a/src/spanreed/apis/telegram_bot.py
+++ b/src/spanreed/apis/telegram_bot.py
@@ -22,10 +22,11 @@ from telegram import (
     Message,
 )
 from telegram.error import (
-    TelegramError,
     RetryAfter,
     TimedOut,
     NetworkError,
+    BadRequest,
+    Forbidden,
 )
 from telegram.ext import (
     ApplicationBuilder,
@@ -642,7 +643,9 @@ class TelegramBotApi:
 
         Pushes them back on the right (oldest) end so they keep FIFO priority.
         """
-        while (item := await redis_api.lpop(self._outbound_inflight_key())) is not None:
+        while (
+            item := await redis_api.lpop(self._outbound_inflight_key())
+        ) is not None:
             await redis_api.rpush(self._outbound_key(), item)
 
     async def _deliver_one(self, raw: bytes | str) -> None:
@@ -653,7 +656,9 @@ class TelegramBotApi:
             parse_html = message.get("parse_html", True)
             parse_markdown = message.get("parse_markdown", False)
         except (ValueError, KeyError, TypeError):
-            self._logger.exception(f"Dropping malformed outbound entry: {raw!r}")
+            self._logger.exception(
+                f"Dropping malformed outbound entry: {raw!r}"
+            )
             await redis_api.lrem(self._outbound_inflight_key(), 1, raw)
             return
 
@@ -667,6 +672,13 @@ class TelegramBotApi:
                 )
             except asyncio.CancelledError:
                 raise
+            except (BadRequest, Forbidden):
+                # Permanent (bad markup, message too long, bot blocked):
+                # retrying can't help, so drop it. Caught before the transient
+                # branch because BadRequest is a subclass of NetworkError.
+                self._logger.exception(
+                    f"Dropping undeliverable outbound message: {text!r}"
+                )
             except (RetryAfter, TimedOut, NetworkError, TimeoutError) as e:
                 # Transient: Telegram is throttling/unreachable. Wait and
                 # retry the *same* message (it stays reserved in inflight).
@@ -679,8 +691,8 @@ class TelegramBotApi:
                 backoff = min(backoff * 2, OUTBOUND_MAX_BACKOFF_S)
                 continue
             except Exception:
-                # Permanent (bad markup, message too long, bot blocked, or an
-                # unexpected error): drop it rather than wedge the queue.
+                # Any other error (unexpected / non-Telegram): drop rather
+                # than wedge the queue.
                 self._logger.exception(
                     f"Dropping undeliverable outbound message: {text!r}"
                 )

--- a/src/spanreed/apis/telegram_bot.py
+++ b/src/spanreed/apis/telegram_bot.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import datetime
+import json
 import os
 from enum import auto, IntEnum
 import logging
@@ -10,6 +11,7 @@ from dataclasses import dataclass
 from collections.abc import AsyncGenerator
 
 from spanreed.plugin import Plugin
+from spanreed.storage import redis_api
 from spanreed.user import User
 
 from telegram import (
@@ -19,7 +21,12 @@ from telegram import (
     constants,
     Message,
 )
-from telegram.error import TelegramError
+from telegram.error import (
+    TelegramError,
+    RetryAfter,
+    TimedOut,
+    NetworkError,
+)
 from telegram.ext import (
     ApplicationBuilder,
     AIORateLimiter,
@@ -38,6 +45,13 @@ USER_INTERACTION_LOCKS = "user-interaction-locks"
 USER_INTERACTION_QUEUES = "user-interaction-queue"
 CURRENT_USER_INTERACTION = "current-user-interaction"
 USER_MESSAGE_CALLBACK_ID = "user-message-callback-id"
+
+# Durable outbound notification queue. `notify()` enqueues here; a per-user
+# consumer (started by TelegramBotPlugin) drains it, so notifications survive
+# restarts and Telegram flood-control bans instead of being dropped.
+OUTBOUND_QUEUE_MAX = 200  # keep newest N; drop older on overflow
+OUTBOUND_INITIAL_BACKOFF_S = 60
+OUTBOUND_MAX_BACKOFF_S = 30 * 60
 
 
 class CallbackData(NamedTuple):
@@ -88,6 +102,10 @@ class TelegramBotPlugin(Plugin[UserConfig]):
             TelegramBotApi._application_initialized.set()
             TelegramBotApi._application = application
 
+            # Start the durable outbound-message consumer for each user so
+            # queued notifications (see TelegramBotApi.notify) get delivered.
+            await self._start_outbound_consumers()
+
             try:
                 # Wait for cancellation so we can perform the cleanup.
                 self._logger.info("Waiting for cancellation...")
@@ -104,6 +122,16 @@ class TelegramBotPlugin(Plugin[UserConfig]):
                 await application.stop()
                 self._logger.info("Stopped")
                 raise
+
+    async def _start_outbound_consumers(self) -> None:
+        for user in await self.get_users():
+            bot = await TelegramBotApi.for_user(user)
+            task = asyncio.create_task(bot.deliver_outbound_messages())
+            self.background_tasks.add(task)
+            task.add_done_callback(self.background_tasks.discard)
+            self._logger.info(
+                f"Started outbound-message consumer for user {user.id}"
+            )
 
     async def setup_application(
         self,
@@ -532,31 +560,133 @@ class TelegramBotApi:
                 ),
             )
 
+    def _outbound_key(self) -> str:
+        return f"outbound-messages:{self._telegram_user_id}"
+
+    def _outbound_inflight_key(self) -> str:
+        return f"outbound-messages:inflight:{self._telegram_user_id}"
+
     async def notify(
         self,
         text: str,
         *,
         parse_html: bool = True,
         parse_markdown: bool = False,
-    ) -> Message | None:
-        """Best-effort notification: deliver `text`, but never raise.
+    ) -> None:
+        """Fire-and-forget, durable notification.
 
-        Use for fire-and-forget confirmations (e.g. "Logged X") where a
-        failed or rate-limited send must not abort the work that produced it,
-        nor crash the calling loop. Returns the sent Message, or None if
-        delivery failed.
+        Enqueues `text` to a per-user Redis queue that a background consumer
+        (see `deliver_outbound_messages`) drains in FIFO order. Delivery
+        survives process restarts and Telegram flood-control bans, so a
+        rate-limited or failed send never aborts the work that produced it
+        nor crashes the calling loop.
+
+        Use this for fire-and-forget confirmations and notices (e.g.
+        "Logged X", "Spanreed is starting up"). For interactive messages that
+        must arrive immediately or surface their failure (prompts, the auth
+        link), use `send_message`.
         """
+        entry = json.dumps(
+            {
+                "id": uuid.uuid4().hex,
+                "text": text,
+                "parse_html": parse_html,
+                "parse_markdown": parse_markdown,
+                "enqueued_at": datetime.datetime.now(
+                    datetime.timezone.utc
+                ).isoformat(),
+            }
+        )
+        key = self._outbound_key()
+        await redis_api.lpush(key, entry)
+        # Bound the backlog so a long outage can't grow it without limit.
+        # New entries are pushed on the left, so keeping [0, MAX) retains the
+        # newest and drops the oldest undelivered ones.
+        await redis_api.ltrim(key, 0, OUTBOUND_QUEUE_MAX - 1)
+
+    async def deliver_outbound_messages(self) -> None:
+        """Drain the durable outbound queue for this user, forever.
+
+        Started once per user by TelegramBotPlugin. Reserves each message
+        into an inflight list (crash-safe), delivers it, and only then acks
+        by removing it. Backs off on transient failures (flood control,
+        timeouts, network) so a ban doesn't turn into a hammering loop, and
+        drops messages that are permanently undeliverable (bad markup, etc.)
+        so a single poison message can't wedge the queue.
+        """
+        await self._recover_inflight()
+        while True:
+            try:
+                # Reserve the oldest message (queue tail) into the inflight
+                # list atomically, so a crash mid-send can't lose it.
+                raw = await redis_api.brpoplpush(
+                    self._outbound_key(),
+                    self._outbound_inflight_key(),
+                    timeout=30,
+                )
+                if raw is None:
+                    continue
+                await self._deliver_one(raw)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # Never let the consumer die (e.g. a Redis blip); back off
+                # briefly and keep going.
+                self._logger.exception(
+                    "Outbound delivery loop error; retrying in 5s."
+                )
+                await asyncio.sleep(5)
+
+    async def _recover_inflight(self) -> None:
+        """Return messages reserved but not acked before a crash to the queue.
+
+        Pushes them back on the right (oldest) end so they keep FIFO priority.
+        """
+        while (item := await redis_api.lpop(self._outbound_inflight_key())) is not None:
+            await redis_api.rpush(self._outbound_key(), item)
+
+    async def _deliver_one(self, raw: bytes | str) -> None:
+        """Deliver one reserved message, retrying until it sticks or is dropped."""
         try:
-            return await self.send_message(
-                text,
-                parse_html=parse_html,
-                parse_markdown=parse_markdown,
-            )
-        except (TelegramError, TimeoutError):
-            self._logger.warning(
-                f"Failed to deliver notification: {text!r}", exc_info=True
-            )
-            return None
+            message = json.loads(raw)
+            text = message["text"]
+            parse_html = message.get("parse_html", True)
+            parse_markdown = message.get("parse_markdown", False)
+        except (ValueError, KeyError, TypeError):
+            self._logger.exception(f"Dropping malformed outbound entry: {raw!r}")
+            await redis_api.lrem(self._outbound_inflight_key(), 1, raw)
+            return
+
+        backoff = OUTBOUND_INITIAL_BACKOFF_S
+        while True:
+            try:
+                await self.send_message(
+                    text,
+                    parse_html=parse_html,
+                    parse_markdown=parse_markdown,
+                )
+            except asyncio.CancelledError:
+                raise
+            except (RetryAfter, TimedOut, NetworkError, TimeoutError) as e:
+                # Transient: Telegram is throttling/unreachable. Wait and
+                # retry the *same* message (it stays reserved in inflight).
+                retry_after = getattr(e, "retry_after", None)
+                delay = min(retry_after or backoff, OUTBOUND_MAX_BACKOFF_S)
+                self._logger.warning(
+                    f"Outbound delivery deferred ({e!r}); retrying in {delay}s."
+                )
+                await asyncio.sleep(delay)
+                backoff = min(backoff * 2, OUTBOUND_MAX_BACKOFF_S)
+                continue
+            except Exception:
+                # Permanent (bad markup, message too long, bot blocked, or an
+                # unexpected error): drop it rather than wedge the queue.
+                self._logger.exception(
+                    f"Dropping undeliverable outbound message: {text!r}"
+                )
+            # Delivered or permanently dropped: ack by removing from inflight.
+            await redis_api.lrem(self._outbound_inflight_key(), 1, raw)
+            return
 
     async def send_multiple_messages(
         self, *text: str, delay: int = 1, parse_html: bool = True

--- a/src/spanreed/apis/telegram_bot_test.py
+++ b/src/spanreed/apis/telegram_bot_test.py
@@ -1,8 +1,12 @@
 import asyncio
+import contextlib
+import json
 import pytest
 from unittest.mock import AsyncMock, patch
 
-from spanreed.apis.telegram_bot import TelegramBotApi
+from telegram.error import RetryAfter, BadRequest
+
+from spanreed.apis.telegram_bot import TelegramBotApi, OUTBOUND_QUEUE_MAX
 from spanreed.user import User
 
 
@@ -107,3 +111,201 @@ def test_user_interaction_handles_early_cancellation_properly(
 
     # Run the async test function
     asyncio.run(run_test())
+
+
+# ---------------------------------------------------------------------------
+# Durable outbound notification queue
+# ---------------------------------------------------------------------------
+
+OUTBOUND_USER_ID = 123
+QUEUE = f"outbound-messages:{OUTBOUND_USER_ID}"
+INFLIGHT = f"outbound-messages:inflight:{OUTBOUND_USER_ID}"
+
+
+class FakeRedis:
+    """In-memory stand-in for the Redis list ops the outbound queue uses.
+
+    Lists are modeled head-first (index 0 == left/head), matching Redis:
+    LPUSH inserts at the head, so the tail is the oldest element.
+    """
+
+    def __init__(self) -> None:
+        self.lists: dict[str, list] = {}
+
+    async def lpush(self, key: str, *values: object) -> int:
+        lst = self.lists.setdefault(key, [])
+        for value in values:
+            lst.insert(0, value)
+        return len(lst)
+
+    async def rpush(self, key: str, *values: object) -> int:
+        lst = self.lists.setdefault(key, [])
+        lst.extend(values)
+        return len(lst)
+
+    async def lpop(self, key: str) -> object | None:
+        lst = self.lists.get(key, [])
+        return lst.pop(0) if lst else None
+
+    async def ltrim(self, key: str, start: int, end: int) -> bool:
+        lst = self.lists.get(key, [])
+        self.lists[key] = lst[start : end + 1]
+        return True
+
+    async def brpoplpush(
+        self, src: str, dst: str, timeout: int = 0
+    ) -> object | None:
+        lst = self.lists.get(src, [])
+        if not lst:
+            return None
+        value = lst.pop()  # tail == oldest
+        self.lists.setdefault(dst, []).insert(0, value)
+        return value
+
+    async def lrem(self, key: str, count: int, value: object) -> int:
+        lst = self.lists.get(key, [])
+        removed = 0
+        while value in lst and (count == 0 or removed < count):
+            lst.remove(value)
+            removed += 1
+        return removed
+
+
+class FakeRedisCancelOnEmpty(FakeRedis):
+    """FakeRedis whose blocking pop raises CancelledError when the queue is
+
+    empty, so the consumer loop terminates in a test once it has drained.
+    """
+
+    async def brpoplpush(
+        self, src: str, dst: str, timeout: int = 0
+    ) -> object | None:
+        value = await super().brpoplpush(src, dst, timeout)
+        if value is None:
+            raise asyncio.CancelledError
+        return value
+
+
+def _outbound_bot(fake: FakeRedis) -> TelegramBotApi:
+    bot = TelegramBotApi(OUTBOUND_USER_ID)
+    bot.send_message = AsyncMock()  # type: ignore[method-assign]
+    return bot
+
+
+def test_notify_enqueues_and_bounds_backlog() -> None:
+    fake = FakeRedis()
+    with patch("spanreed.apis.telegram_bot.redis_api", new=fake):
+        bot = _outbound_bot(fake)
+
+        async def go() -> None:
+            for i in range(OUTBOUND_QUEUE_MAX + 5):
+                await bot.notify(f"m{i}")
+
+        asyncio.run(go())
+
+    # Backlog is capped, keeping the newest entries.
+    assert len(fake.lists[QUEUE]) == OUTBOUND_QUEUE_MAX
+    newest = json.loads(fake.lists[QUEUE][0])
+    assert newest["text"] == f"m{OUTBOUND_QUEUE_MAX + 4}"
+
+
+def test_deliver_one_success_acks() -> None:
+    fake = FakeRedis()
+    raw = json.dumps({"text": "hello", "parse_html": True})
+    fake.lists[INFLIGHT] = [raw]
+    with patch("spanreed.apis.telegram_bot.redis_api", new=fake):
+        bot = _outbound_bot(fake)
+        asyncio.run(bot._deliver_one(raw))
+
+    bot.send_message.assert_awaited_once_with(
+        "hello", parse_html=True, parse_markdown=False
+    )
+    assert fake.lists[INFLIGHT] == []  # acked
+
+
+def test_deliver_one_retries_transient_then_acks() -> None:
+    fake = FakeRedis()
+    raw = json.dumps({"text": "hi"})
+    fake.lists[INFLIGHT] = [raw]
+    with (
+        patch("spanreed.apis.telegram_bot.redis_api", new=fake),
+        patch("asyncio.sleep", new=AsyncMock()) as mock_sleep,
+    ):
+        bot = _outbound_bot(fake)
+        bot.send_message = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[RetryAfter(2), None]
+        )
+        asyncio.run(bot._deliver_one(raw))
+
+    assert bot.send_message.await_count == 2
+    mock_sleep.assert_awaited()  # it backed off before retrying
+    assert fake.lists[INFLIGHT] == []  # eventually acked
+
+
+def test_deliver_one_drops_permanent_error() -> None:
+    fake = FakeRedis()
+    raw = json.dumps({"text": "bad markup"})
+    fake.lists[INFLIGHT] = [raw]
+    with patch("spanreed.apis.telegram_bot.redis_api", new=fake):
+        bot = _outbound_bot(fake)
+        bot.send_message = AsyncMock(  # type: ignore[method-assign]
+            side_effect=BadRequest("nope")
+        )
+        asyncio.run(bot._deliver_one(raw))
+
+    # Tried once, then dropped (removed from inflight) rather than retried.
+    bot.send_message.assert_awaited_once()
+    assert fake.lists[INFLIGHT] == []
+
+
+def test_deliver_one_drops_malformed_entry() -> None:
+    fake = FakeRedis()
+    raw = "this is not json"
+    fake.lists[INFLIGHT] = [raw]
+    with patch("spanreed.apis.telegram_bot.redis_api", new=fake):
+        bot = _outbound_bot(fake)
+        asyncio.run(bot._deliver_one(raw))
+
+    bot.send_message.assert_not_awaited()
+    assert fake.lists[INFLIGHT] == []
+
+
+def test_recover_inflight_returns_messages_to_queue_tail() -> None:
+    fake = FakeRedis()
+    fake.lists[INFLIGHT] = ["stranded"]
+    fake.lists[QUEUE] = ["newer"]  # already queued (head == newest)
+    with patch("spanreed.apis.telegram_bot.redis_api", new=fake):
+        bot = _outbound_bot(fake)
+        asyncio.run(bot._recover_inflight())
+
+    assert fake.lists[INFLIGHT] == []
+    # Recovered message goes to the tail (oldest), so it is delivered first.
+    assert fake.lists[QUEUE][-1] == "stranded"
+
+
+def test_consumer_drains_fifo_and_recovers_inflight() -> None:
+    fake = FakeRedisCancelOnEmpty()
+    # A message reserved but not acked before a crash.
+    fake.lists[INFLIGHT] = [json.dumps({"text": "stranded"})]
+
+    sent: list[str] = []
+
+    def collect(text: str, **_kwargs: object) -> None:
+        sent.append(text)
+
+    with patch("spanreed.apis.telegram_bot.redis_api", new=fake):
+        bot = _outbound_bot(fake)
+        bot.send_message = AsyncMock(side_effect=collect)  # type: ignore[method-assign]
+
+        async def go() -> None:
+            await bot.notify("a")
+            await bot.notify("b")
+            with contextlib.suppress(asyncio.CancelledError):
+                await bot.deliver_outbound_messages()
+
+        asyncio.run(go())
+
+    # Recovered message delivered first, then the queue in FIFO order.
+    assert sent == ["stranded", "a", "b"]
+    assert fake.lists.get(QUEUE, []) == []
+    assert fake.lists.get(INFLIGHT, []) == []

--- a/src/spanreed/plugins/spanreed_monitor.py
+++ b/src/spanreed/plugins/spanreed_monitor.py
@@ -9,7 +9,6 @@ from contextlib import suppress, asynccontextmanager
 from typing import AsyncGenerator
 
 import redis
-import telegram.error
 
 from spanreed.apis.telegram_bot import TelegramBotApi
 from spanreed.user import User
@@ -37,7 +36,9 @@ class SpanreedMonitorPlugin(Plugin):
 
     async def _monitor_exceptions(self, user: User) -> None:
         bot: TelegramBotApi = await TelegramBotApi.for_user(user)
-        await bot.send_message("Spanreed is starting up.")
+        # Durable: delivered once the bot can send, even if it's flood-limited
+        # at startup.
+        await bot.notify("Spanreed is starting up.")
 
         interval: datetime.timedelta = datetime.timedelta(days=1, hours=6)
 
@@ -48,18 +49,21 @@ class SpanreedMonitorPlugin(Plugin):
                         _, exception = await redis_api.blpop(
                             self.EXCEPTION_QUEUE_NAME
                         )
-                        with suppress(telegram.error.BadRequest):
-                            await bot.send_message(
-                                f"Exception retrieved from storage:\n\n"
-                                f"```python\n{str(exception.decode('utf-8'))}\n```",
-                                parse_html=False,
-                                parse_markdown=True,
-                            )
-                        await bot.send_message("Spanreed is still running.")
+                        await bot.notify(
+                            f"Exception retrieved from storage:\n\n"
+                            f"```python\n{str(exception.decode('utf-8'))}\n```",
+                            parse_html=False,
+                            parse_markdown=True,
+                        )
+                        await bot.notify("Spanreed is still running.")
                         await redis_api.delete(self.EXCEPTION_QUEUE_NAME)
         except asyncio.CancelledError:
             self._logger.info("Spanreed Monitor cancelled.")
-            await bot.send_message("Spanreed is shutting down.")
+            # Best-effort immediate send: the process (and the outbound
+            # consumer) is going away, so a queued message wouldn't be
+            # delivered until the next startup.
+            with suppress(Exception):
+                await bot.send_message("Spanreed is shutting down.")
 
     async def _monitor_obsidian_plugin(self, user: User) -> None:
         from spanreed.apis.obsidian import ObsidianPlugin


### PR DESCRIPTION
## What
Adds a durable, per-user outbound notification queue (item 4 of the flood-control series). `notify()` now enqueues to Redis and a background consumer delivers, so notices survive process restarts **and** active Telegram flood-control bans instead of being dropped.

## Why
Even after the rate limiter (#9), supervisor (#10), and best-effort `notify` (#11), two things were still lost during a ban:
- The startup notice — `spanreed_monitor` did a plain `send_message("Spanreed is starting up.")`, which fails during a ban.
- Error notices — the exception monitor did `blpop` (removes the item) *then* `send_message`; if that send failed, the popped exception was gone.

## Design
- **`notify()` = durable enqueue.** `LPUSH` to `outbound-messages:{uid}`, bounded with `LTRIM` to the newest N (drops oldest on overflow). Every existing `bot.notify(...)` call site is unchanged but now durable.
- **One consumer per user** (`deliver_outbound_messages`), started by `TelegramBotPlugin` once the app is up.
  - Reserves each message into `outbound-messages:inflight:{uid}` via `BRPOPLPUSH` (crash-safe), delivers, then acks with `LREM` — at-least-once.
  - **Transient** errors (`RetryAfter` / `TimedOut` / `NetworkError` / `TimeoutError`) → back off (uses `retry_after` when present, else exponential up to 30 min) and retry the same message, so a ban can't become a hammering loop.
  - **Permanent** errors (bad markup, message too long, bot blocked, unexpected) → log and drop, so one poison message can't wedge the queue.
  - On startup, `_recover_inflight` returns any messages reserved-but-not-acked before a crash back to the queue (FIFO preserved).
- `send_message` is unchanged — still immediate and raises, for interactive/must-surface messages (prompts, the Withings auth link).
- `spanreed_monitor`: startup / "still running" / exception notices now use `notify()`; the **shutdown** notice stays an immediate best-effort `send_message` (the process and the consumer are exiting, so a queued message would never be delivered).

Compatibility: uses `BRPOPLPUSH` / `LPOP` / `RPUSH` (available on all Redis versions) rather than `LMOVE`/`BLMOVE` (6.2+), since the managed Redis version is unknown.

## Tradeoffs (discussed and accepted)
- After a ban lifts you may get a burst of stale "Logged X" messages — they're timestamped, so it reads fine.
- Notifications flow through the consumer, so they can interleave with immediate interactive `send_message`s; in practice they rarely overlap in time.

## Testing
Byte-compiles clean. The Redis list direction semantics (FIFO via `LPUSH`+`BRPOPLPUSH`, `LTRIM` drops oldest, recovery order) were validated with a standalone simulation. I could not run the pytest suite locally (the project venv only exists on the server); no existing tests cover this path. A unit test with a fake Redis would be a good follow-up — happy to add one.

## Deploy note
No new dependency. Needs the usual service restart to start the consumers.
