### PR TITLE
Migrate Todoist integration to the new API (todoist-api-python v3)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -150,6 +150,18 @@ files = [
 frozenlist = ">=1.1.0"
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+description = "Reusable constraint types to use with typing.Annotated"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
+    {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
+]
+
+[[package]]
 name = "anyio"
 version = "4.8.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
@@ -580,6 +592,54 @@ sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
 test = ["certifi (>=2024)", "cryptography-vectors (==44.0.0)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
 test-randomorder = ["pytest-randomly"]
+
+[[package]]
+name = "dataclass-wizard"
+version = "0.35.3"
+description = "Lightning-fast JSON wizardry for Python dataclasses — effortless serialization right out of the box!"
+optional = false
+python-versions = "*"
+groups = ["main"]
+markers = "python_version == \"3.12\""
+files = [
+    {file = "dataclass_wizard-0.35.3-py2.py3-none-any.whl", hash = "sha256:eb0cf55b03691edf40db5203b064e5d6ed658335ba3176ab10df52a464056dd3"},
+    {file = "dataclass_wizard-0.35.3.tar.gz", hash = "sha256:6fa25134e72dd6944482864b9e51fc7ae9a7b31b2073c035a08085be667301f2"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.9.0", markers = "python_version <= \"3.12\""}
+
+[package.extras]
+dev = ["Sphinx (==7.4.7) ; python_version == \"3.9\"", "Sphinx (==8.1.3) ; python_version >= \"3.10\"", "attrs (==24.3.0)", "bump2version (==1.0.1)", "coverage (>=6.2)", "dacite (==1.8.1)", "dataclass-factory (==2.16)", "dataclass-wizard[toml]", "dataclasses-json (==0.6.7)", "flake8 (>=3)", "jsons (==1.6.3)", "mashumaro (==3.15)", "matplotlib", "pip (>=21.3.1)", "pydantic (==2.10.3)", "pytest (==8.3.4)", "pytest-benchmark[histogram]", "pytest-cov (==6.0.0)", "pytest-mock (>=3.6.1)", "python-dotenv (>=1,<2)", "pytimeparse (==1.1.8)", "sphinx-autodoc-typehints (==2.5.0) ; python_version >= \"3.10\"", "sphinx-copybutton (==0.5.2)", "sphinx-issues (==5.0.0)", "tomli (>=2,<3) ; python_version == \"3.10\"", "tomli (>=2,<3) ; python_version == \"3.9\"", "tomli-w (>=1,<2)", "tox (==4.23.2)", "twine (==6.0.1)", "typing-extensions (>=4.9.0)", "watchdog[watchmedo] (==6.0.0)", "wheel (==0.45.1)"]
+dotenv = ["python-dotenv (>=1,<2)"]
+timedelta = ["pytimeparse (>=1.1.7)"]
+toml = ["tomli (>=2,<3) ; python_version == \"3.10\"", "tomli (>=2,<3) ; python_version == \"3.9\"", "tomli-w (>=1,<2)"]
+yaml = ["PyYAML (>=6,<7)"]
+
+[[package]]
+name = "dataclass-wizard"
+version = "0.39.1"
+description = "A wizard-like JSON serialization library for Python dataclasses"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "python_version >= \"3.13\""
+files = [
+    {file = "dataclass_wizard-0.39.1-py3-none-any.whl", hash = "sha256:3324e59eca705882eb34e2b3989b2beadd8c2b523e6269d4002cf1a4a5bf703b"},
+    {file = "dataclass_wizard-0.39.1.tar.gz", hash = "sha256:1679948ed7c62103f40b34df97d03b35e6b2ad50f58173fdbe30074e2e4730f2"},
+]
+
+[package.extras]
+all = ["PyYAML (>=6,<7)", "Sphinx (==7.4.7) ; python_version == \"3.9\"", "Sphinx (==8.1.3) ; python_version >= \"3.10\"", "attrs (==25.4.0)", "bump-my-version (==1.2.5)", "coverage (>=6.2)", "dacite (==1.9.2)", "dataclass-factory (==2.16)", "dataclasses-json (==0.6.7)", "flake8 (>=3)", "jsons (==1.6.3)", "mashumaro (==3.17)", "matplotlib", "mypy (>=1.19,<2)", "pydantic (==2.12.5)", "pytest (==8.3.4)", "pytest-benchmark[histogram]", "pytest-cov (==6.0.0)", "pytest-mock (>=3.6.1)", "python-dotenv (>=1,<2)", "pytimeparse (==1.1.8)", "pytimeparse (>=1.1.7)", "sphinx-autodoc-typehints (==2.5.0) ; python_version >= \"3.10\"", "sphinx-copybutton (==0.5.2)", "sphinx-issues (==5.0.0)", "tomli (>=2,<3) ; python_version == \"3.10\"", "tomli (>=2,<3) ; python_version == \"3.9\"", "tomli-w (>=1,<2)", "tox (==4.23.2)", "twine (==6.0.1)", "typing-extensions (>=4.9.0)", "tzdata (>=2024.1) ; platform_system == \"Windows\"", "watchdog[watchmedo] (==6.0.0)", "wheel (==0.45.1)"]
+bench = ["attrs (==25.4.0)", "dacite (==1.9.2)", "dataclass-factory (==2.16)", "dataclasses-json (==0.6.7)", "jsons (==1.6.3)", "mashumaro (==3.17)", "matplotlib", "pydantic (==2.12.5)", "pytest-benchmark[histogram]"]
+dev = ["Sphinx (==7.4.7) ; python_version == \"3.9\"", "Sphinx (==8.1.3) ; python_version >= \"3.10\"", "bump-my-version (==1.2.5)", "coverage (>=6.2)", "dataclass-wizard[toml]", "flake8 (>=3)", "mypy (>=1.19,<2)", "pip (>=21.3.1)", "python-dotenv (>=1,<2)", "pytimeparse (==1.1.8)", "tomli (>=2,<3) ; python_version == \"3.10\"", "tomli (>=2,<3) ; python_version == \"3.9\"", "tomli-w (>=1,<2)", "tox (==4.23.2)", "twine (==6.0.1)", "tzdata (>=2024.1) ; platform_system == \"Windows\"", "watchdog[watchmedo] (==6.0.0)", "wheel (==0.45.1)"]
+docs = ["sphinx-autodoc-typehints (==2.5.0) ; python_version >= \"3.10\"", "sphinx-copybutton (==0.5.2)", "sphinx-issues (==5.0.0)", "typing-extensions (>=4.9.0)"]
+dotenv = ["python-dotenv (>=1,<2)"]
+test = ["pytest (==8.3.4)", "pytest-cov (==6.0.0)", "pytest-mock (>=3.6.1)", "tzdata (>=2024.1) ; platform_system == \"Windows\""]
+timedelta = ["pytimeparse (>=1.1.7)"]
+toml = ["tomli (>=2,<3) ; python_version == \"3.10\"", "tomli (>=2,<3) ; python_version == \"3.9\"", "tomli-w (>=1,<2)"]
+tz = ["tzdata (>=2024.1)"]
+yaml = ["PyYAML (>=6,<7)"]
 
 [[package]]
 name = "flask"
@@ -1890,18 +1950,20 @@ files = [
 
 [[package]]
 name = "todoist-api-python"
-version = "2.1.7"
-description = "Official Python SDK for the Todoist REST API."
+version = "3.2.1"
+description = "Official Python SDK for the Todoist API."
 optional = false
-python-versions = "<4.0,>=3.9"
+python-versions = "~=3.9"
 groups = ["main"]
 files = [
-    {file = "todoist_api_python-2.1.7-py3-none-any.whl", hash = "sha256:278bfe851b9bd19bde5ff5de09d813d671ef7310ba55e1962131fca5b59bb735"},
-    {file = "todoist_api_python-2.1.7.tar.gz", hash = "sha256:84934a19ccd83fb61010a8126362a5d7d6486c92454c111307ba55bc74903f5c"},
+    {file = "todoist_api_python-3.2.1-py3-none-any.whl", hash = "sha256:1091e9b557291380abd79245efe961b0f2261c7b4eb16e52beccfc6357320e95"},
+    {file = "todoist_api_python-3.2.1.tar.gz", hash = "sha256:22c60230cc616437846f9a6469dddd97548545ef916d2bea98b2ca2f522d92f9"},
 ]
 
 [package.dependencies]
-requests = ">=2.32.3,<3.0.0"
+annotated-types = "*"
+dataclass-wizard = ">=0.35.0,<1.0"
+requests = ">=2.32.3,<3"
 
 [[package]]
 name = "types-cffi"
@@ -2208,4 +2270,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "a5bab3523bbcdd128f86d8f9a03299d144d203918f22b88dab86bcd0894de4ad"
+content-hash = "c9b385e4bb5076f4bfe8778450bfc73c609ba122a27c4a5fcac3d6174a786c30"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-todoist-api-python = "*"
+todoist-api-python = "^3.2.1"
 python-telegram-bot = {extras = ["job-queue", "callback-data", "rate-limiter"], version = "^20.1"}
 redis = "*"
 python-dateutil = "*"

--- a/src/spanreed/apis/todoist.py
+++ b/src/spanreed/apis/todoist.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import logging
-from typing import Any, TypeVar, Callable, Awaitable, cast
+from typing import Any, TypeVar, Callable, Awaitable, AsyncIterator
 import asyncio
 from functools import wraps
 
@@ -75,17 +75,27 @@ class Todoist:
     async def add_task(self, **kwargs: Any) -> Task:
         return await self._wrapped_api_call(self._api.add_task, **kwargs)
 
-    async def update_task(self, task: Task, **kwargs: Any) -> bool:
+    async def update_task(self, task: Task, **kwargs: Any) -> Task:
+        # The new Todoist API's update_task can't change a task's project;
+        # moving between projects is a separate operation.
+        project_id = kwargs.pop("project_id", None)
+        if project_id is not None:
+            await self._wrapped_api_call(
+                self._api.move_task, task.id, project_id=project_id
+            )
         return await self._wrapped_api_call(
             self._api.update_task, task.id, **kwargs
         )
 
     async def add_comment(self, task: Task, **kwargs: Any) -> Comment:
+        # The new API's add_comment takes the content positionally and the
+        # target as a keyword, so pass task_id explicitly (kwargs carries
+        # `content`).
         return await self._wrapped_api_call(
-            self._api.add_comment, task.id, **kwargs
+            self._api.add_comment, task_id=task.id, **kwargs
         )
 
-    async def update_comment(self, comment: Comment, **kwargs: Any) -> bool:
+    async def update_comment(self, comment: Comment, **kwargs: Any) -> Comment:
         return await self._wrapped_api_call(
             self._api.update_comment, comment.id, **kwargs
         )
@@ -95,7 +105,7 @@ class Todoist:
         task: Task,
         create: bool = False,
     ) -> Comment:
-        comments: list[Comment] = await self._wrapped_api_call(
+        comments: list[Comment] = await self._collect(
             self._api.get_comments, task_id=task.id
         )
         for comment in comments:
@@ -114,7 +124,7 @@ class Todoist:
         )
 
     async def _get_inbox_project(self) -> Project:
-        projects = await self._wrapped_api_call(self._api.get_projects)
+        projects = await self._collect(self._api.get_projects)
         for project in projects:
             if project.is_inbox_project:
                 return project
@@ -122,7 +132,7 @@ class Todoist:
         raise RuntimeError("No inbox project found")
 
     async def get_inbox_tasks(self) -> list[Task]:
-        return await self._wrapped_api_call(
+        return await self._collect(
             self._api.get_tasks,
             project_id=(await self._get_inbox_project()).id,
         )
@@ -132,16 +142,16 @@ class Todoist:
         # associated time-of-day that's in the future - this is because
         # due time-of-day usually indicates _start_ time, not due time.
         query = "overdue | (today & no time) | due before:+0 hours"
-        return await self._wrapped_api_call(self._api.get_tasks, filter=query)
+        return await self._collect(self._api.filter_tasks, query=query)
 
     async def get_tasks_with_label(self, label: str) -> list[Task]:
         # By default, only non-completed tasks are returned.
         query = f"@{label}"
-        return await self._wrapped_api_call(self._api.get_tasks, filter=query)
+        return await self._collect(self._api.filter_tasks, query=query)
 
     async def get_overdue_tasks_with_label(self, label: str) -> list[Task]:
         query = f"@{label} & overdue"
-        return await self._wrapped_api_call(self._api.get_tasks, filter=query)
+        return await self._collect(self._api.filter_tasks, query=query)
 
     async def set_due_date_to_today(self, task: Task) -> None:
         self._logger.info(f"Updating {format_task(task)} due date to today")
@@ -164,7 +174,7 @@ class Todoist:
             )
 
     async def get_projects(self) -> list[Project]:
-        return await self._wrapped_api_call(self._api.get_projects)
+        return await self._collect(self._api.get_projects)
 
     @with_retries()
     async def _wrapped_api_call(
@@ -173,5 +183,23 @@ class Todoist:
         *args: Any,
         **kwargs: Any,
     ) -> T:
-        """Wrapper for Todoist API calls that adds retry logic."""
+        """Wrapper for single Todoist API calls that adds retry logic."""
         return await api_method(*args, **kwargs)
+
+    @with_retries()
+    async def _collect(
+        self,
+        api_method: Callable[..., Awaitable[AsyncIterator[list[T]]]],
+        **kwargs: Any,
+    ) -> list[T]:
+        """Flatten a paginated endpoint into a single list.
+
+        The new Todoist API's list endpoints (get_tasks, filter_tasks,
+        get_comments, get_projects) are coroutines that return an async
+        iterator of pages.
+        """
+        paginator: AsyncIterator[list[T]] = await api_method(**kwargs)
+        results: list[T] = []
+        async for page in paginator:
+            results.extend(page)
+        return results

--- a/src/spanreed/apis/todoist_test.py
+++ b/src/spanreed/apis/todoist_test.py
@@ -1,0 +1,154 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import create_autospec
+
+from todoist_api_python.api_async import TodoistAPIAsync
+
+from spanreed.apis.todoist import Todoist, UserConfig
+
+
+def _todoist() -> Todoist:
+    """A Todoist wrapper whose underlying client is an autospec mock.
+
+    Autospec enforces the real v3 method signatures, so a call the wrapper
+    makes with the wrong arguments fails the test.
+    """
+    td = Todoist(UserConfig(api_token="test-token"))
+    td._api = create_autospec(TodoistAPIAsync, instance=True)
+    return td
+
+
+def _pages(*pages: list) -> object:
+    """An async iterator of pages, matching the v3 paginated endpoints."""
+
+    async def gen() -> object:
+        for page in pages:
+            yield page
+
+    return gen()
+
+
+def _task(
+    task_id: str = "1", content: str = "c", due: object = None
+) -> object:
+    return SimpleNamespace(id=task_id, content=content, due=due)
+
+
+def test_get_overdue_tasks_with_label_flattens_filter() -> None:
+    td = _todoist()
+    t1, t2, t3 = _task("1"), _task("2"), _task("3")
+    td._api.filter_tasks.return_value = _pages([t1, t2], [t3])
+
+    result = asyncio.run(td.get_overdue_tasks_with_label("bills"))
+
+    assert result == [t1, t2, t3]
+    td._api.filter_tasks.assert_awaited_once_with(query="@bills & overdue")
+
+
+def test_get_tasks_with_label_uses_filter_tasks() -> None:
+    td = _todoist()
+    td._api.filter_tasks.return_value = _pages([])
+
+    asyncio.run(td.get_tasks_with_label("bills"))
+
+    td._api.filter_tasks.assert_awaited_once_with(query="@bills")
+
+
+def test_get_due_tasks_uses_filter_tasks() -> None:
+    td = _todoist()
+    td._api.filter_tasks.return_value = _pages([])
+
+    asyncio.run(td.get_due_tasks())
+
+    td._api.filter_tasks.assert_awaited_once_with(
+        query="overdue | (today & no time) | due before:+0 hours"
+    )
+
+
+def test_get_projects_flattens_pages() -> None:
+    td = _todoist()
+    p1 = SimpleNamespace(id="a", is_inbox_project=False)
+    p2 = SimpleNamespace(id="b", is_inbox_project=True)
+    td._api.get_projects.return_value = _pages([p1], [p2])
+
+    assert asyncio.run(td.get_projects()) == [p1, p2]
+
+
+def test_get_inbox_tasks_finds_inbox_then_lists() -> None:
+    td = _todoist()
+    inbox = SimpleNamespace(id="inbox", is_inbox_project=True)
+    other = SimpleNamespace(id="other", is_inbox_project=False)
+    td._api.get_projects.return_value = _pages([other, inbox])
+    task = _task("1")
+    td._api.get_tasks.return_value = _pages([task])
+
+    result = asyncio.run(td.get_inbox_tasks())
+
+    assert result == [task]
+    td._api.get_tasks.assert_awaited_once_with(project_id="inbox")
+
+
+def test_add_comment_passes_task_id_and_content() -> None:
+    td = _todoist()
+    td._api.add_comment.return_value = SimpleNamespace(id="c1", content="x")
+
+    asyncio.run(td.add_comment(_task("42"), content="hello"))
+
+    td._api.add_comment.assert_awaited_once_with(task_id="42", content="hello")
+
+
+def test_update_task_moves_when_project_id_given() -> None:
+    td = _todoist()
+    task = _task("7")
+    td._api.move_task.return_value = True
+    td._api.update_task.return_value = task
+
+    asyncio.run(td.update_task(task, content="new", project_id="proj9"))
+
+    td._api.move_task.assert_awaited_once_with("7", project_id="proj9")
+    td._api.update_task.assert_awaited_once_with("7", content="new")
+
+
+def test_update_task_no_move_without_project_id() -> None:
+    td = _todoist()
+    task = _task("7")
+    td._api.update_task.return_value = task
+
+    asyncio.run(td.update_task(task, content="new"))
+
+    td._api.move_task.assert_not_awaited()
+    td._api.update_task.assert_awaited_once_with("7", content="new")
+
+
+def test_get_first_comment_with_yaml_finds_yaml_comment() -> None:
+    td = _todoist()
+    plain = SimpleNamespace(id="a", content="just text")
+    yaml_comment = SimpleNamespace(id="b", content="---\nkey: v\n---")
+    td._api.get_comments.return_value = _pages([plain, yaml_comment])
+
+    result = asyncio.run(td.get_first_comment_with_yaml(_task("1")))
+
+    assert result is yaml_comment
+    td._api.get_comments.assert_awaited_once_with(task_id="1")
+
+
+def test_set_due_date_to_today_recurring_keeps_recurrence() -> None:
+    td = _todoist()
+    task = _task(
+        "5", due=SimpleNamespace(is_recurring=True, string="every week")
+    )
+    td._api.update_task.return_value = task
+
+    asyncio.run(td.set_due_date_to_today(task))
+
+    td._api.update_task.assert_awaited_once_with("5", due_string="every week")
+
+
+def test_set_due_date_to_today_non_recurring_sets_today() -> None:
+    td = _todoist()
+    task = _task("5", due=None)
+    td._api.update_task.return_value = task
+
+    asyncio.run(td.set_due_date_to_today(task))
+
+    td._api.update_task.assert_awaited_once_with("5", due_string="today")


### PR DESCRIPTION
## What
Migrate the Todoist integration off the retired REST v2 API.

## Why
Todoist sunset the REST v2 API. With `todoist-api-python 2.1.7` (which targets `/rest/v2/*`), **every** Todoist call now fails with `410 Client Error: Gone`. In production this surfaced as the `todoist-no-overdue` plugin crashing on every run (the new supervisor was catching it and retrying every 60s):

```
requests.exceptions.HTTPError: 410 Client Error: Gone for url:
https://api.todoist.com/rest/v2/tasks?filter=%40spanreed%2Fno-overdue+%26+overdue
```

Recurring-payments and the todoist indicator were equally broken — the whole integration was down.

## Change
Upgrade `todoist-api-python` `2.1.7 → ^3.2.1` (first line that targets the new unified API) and adapt the wrapper in `src/spanreed/apis/todoist.py`:

- **Pagination**: `get_tasks` / `get_comments` / `get_projects` are now coroutines returning async iterators of pages. Added a `_collect()` helper (retry-wrapped) that flattens pages into the `list[...]` the callers expect.
- **Filters**: `get_tasks(filter=q)` → `filter_tasks(query=q)`.
- **add_comment**: now takes `content` positionally and `task_id` as a keyword — the wrapper passes `task_id=` explicitly.
- **update_task**: can no longer change a task's project; a `project_id` change is routed through `move_task`.
- Return-type annotations updated (`update_task`/`update_comment` now return the object).

### Why v3, not v4
v4 exists but depends on `httpx >=0.28`, which conflicts with `python-telegram-bot 20.8`'s `httpx ~=0.26` pin (would force a PTB major bump). **v3.2.1 has the same new-API surface but still uses `requests`**, so it drops in with no other dependency changes and the existing `requests`-based 503 retry logic is unchanged.

## Public interface unchanged
The `Todoist` wrapper's method names/signatures/return types are stable, so the plugin call-sites (`recurring_payments`, `todoist_nooverdue`, `todoist_indicator`) and their existing mocked tests need no changes.

## Tests
New `src/spanreed/apis/todoist_test.py` (11 tests) uses `create_autospec(TodoistAPIAsync)` so the wrapper's calls are validated against the **real v3 method signatures**, plus behavior: filter query construction, pagination flattening, inbox lookup, `add_comment` arg translation, the `move_task`-on-project-change path, comment YAML lookup, and recurring/non-recurring due handling. Full suite: **33 passed** locally.

## Not covered
No live API smoke test (no Todoist token available here) — verified via autospec against the installed v3.2.1 library + unit tests. Worth a quick real-call check after deploy (the `todoist-no-overdue` 60s crash loop should stop).

`lock-version` preserved (regenerated with Poetry 2.4.1); new transitive deps: `dataclass-wizard`, `annotated-types`.
