### PR TITLE
Audible: sync listening progress to Obsidian book notes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -233,6 +233,51 @@ tests = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothe
 tests-mypy = ["mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\""]
 
 [[package]]
+name = "audible"
+version = "0.10.0"
+description = "A(Sync) Interface for internal Audible API written in pure Python."
+optional = false
+python-versions = "<3.13,>=3.10"
+groups = ["main"]
+markers = "python_version == \"3.12\""
+files = [
+    {file = "audible-0.10.0-py3-none-any.whl", hash = "sha256:5f59082c0bb07f111a31b86358e07719d57c159bbc144c2724bec0d35a8e7e2c"},
+    {file = "audible-0.10.0.tar.gz", hash = "sha256:125b3accc9ffbda020dd25818264cabe5d748a40559cb9b9c10611d87bb14ebb"},
+]
+
+[package.dependencies]
+beautifulsoup4 = ">=4.11.2"
+httpx = ">=0.23.3"
+pbkdf2 = ">=1.3"
+Pillow = ">=9.4.0"
+pyaes = ">=1.6.1"
+rsa = ">=4.9"
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+description = "Screen-scraping library"
+optional = false
+python-versions = ">=3.7.0"
+groups = ["main"]
+markers = "python_version == \"3.12\""
+files = [
+    {file = "beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9"},
+    {file = "beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7"},
+]
+
+[package.dependencies]
+soupsieve = ">=1.6.1"
+typing-extensions = ">=4.0.0"
+
+[package.extras]
+cchardet = ["cchardet"]
+chardet = ["chardet"]
+charset-normalizer = ["charset-normalizer"]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "black"
 version = "25.1.0"
 description = "The uncompromising code formatter."
@@ -595,39 +640,18 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dataclass-wizard"
-version = "0.35.3"
-description = "Lightning-fast JSON wizardry for Python dataclasses — effortless serialization right out of the box!"
-optional = false
-python-versions = "*"
-groups = ["main"]
-markers = "python_version == \"3.12\""
-files = [
-    {file = "dataclass_wizard-0.35.3-py2.py3-none-any.whl", hash = "sha256:eb0cf55b03691edf40db5203b064e5d6ed658335ba3176ab10df52a464056dd3"},
-    {file = "dataclass_wizard-0.35.3.tar.gz", hash = "sha256:6fa25134e72dd6944482864b9e51fc7ae9a7b31b2073c035a08085be667301f2"},
-]
-
-[package.dependencies]
-typing-extensions = {version = ">=4.9.0", markers = "python_version <= \"3.12\""}
-
-[package.extras]
-dev = ["Sphinx (==7.4.7) ; python_version == \"3.9\"", "Sphinx (==8.1.3) ; python_version >= \"3.10\"", "attrs (==24.3.0)", "bump2version (==1.0.1)", "coverage (>=6.2)", "dacite (==1.8.1)", "dataclass-factory (==2.16)", "dataclass-wizard[toml]", "dataclasses-json (==0.6.7)", "flake8 (>=3)", "jsons (==1.6.3)", "mashumaro (==3.15)", "matplotlib", "pip (>=21.3.1)", "pydantic (==2.10.3)", "pytest (==8.3.4)", "pytest-benchmark[histogram]", "pytest-cov (==6.0.0)", "pytest-mock (>=3.6.1)", "python-dotenv (>=1,<2)", "pytimeparse (==1.1.8)", "sphinx-autodoc-typehints (==2.5.0) ; python_version >= \"3.10\"", "sphinx-copybutton (==0.5.2)", "sphinx-issues (==5.0.0)", "tomli (>=2,<3) ; python_version == \"3.10\"", "tomli (>=2,<3) ; python_version == \"3.9\"", "tomli-w (>=1,<2)", "tox (==4.23.2)", "twine (==6.0.1)", "typing-extensions (>=4.9.0)", "watchdog[watchmedo] (==6.0.0)", "wheel (==0.45.1)"]
-dotenv = ["python-dotenv (>=1,<2)"]
-timedelta = ["pytimeparse (>=1.1.7)"]
-toml = ["tomli (>=2,<3) ; python_version == \"3.10\"", "tomli (>=2,<3) ; python_version == \"3.9\"", "tomli-w (>=1,<2)"]
-yaml = ["PyYAML (>=6,<7)"]
-
-[[package]]
-name = "dataclass-wizard"
 version = "0.39.1"
 description = "A wizard-like JSON serialization library for Python dataclasses"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version >= \"3.13\""
 files = [
     {file = "dataclass_wizard-0.39.1-py3-none-any.whl", hash = "sha256:3324e59eca705882eb34e2b3989b2beadd8c2b523e6269d4002cf1a4a5bf703b"},
     {file = "dataclass_wizard-0.39.1.tar.gz", hash = "sha256:1679948ed7c62103f40b34df97d03b35e6b2ad50f58173fdbe30074e2e4730f2"},
 ]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.13.0", markers = "python_version <= \"3.12\""}
 
 [package.extras]
 all = ["PyYAML (>=6,<7)", "Sphinx (==7.4.7) ; python_version == \"3.9\"", "Sphinx (==8.1.3) ; python_version >= \"3.10\"", "attrs (==25.4.0)", "bump-my-version (==1.2.5)", "coverage (>=6.2)", "dacite (==1.9.2)", "dataclass-factory (==2.16)", "dataclasses-json (==0.6.7)", "flake8 (>=3)", "jsons (==1.6.3)", "mashumaro (==3.17)", "matplotlib", "mypy (>=1.19,<2)", "pydantic (==2.12.5)", "pytest (==8.3.4)", "pytest-benchmark[histogram]", "pytest-cov (==6.0.0)", "pytest-mock (>=3.6.1)", "python-dotenv (>=1,<2)", "pytimeparse (==1.1.8)", "pytimeparse (>=1.1.7)", "sphinx-autodoc-typehints (==2.5.0) ; python_version >= \"3.10\"", "sphinx-copybutton (==0.5.2)", "sphinx-issues (==5.0.0)", "tomli (>=2,<3) ; python_version == \"3.10\"", "tomli (>=2,<3) ; python_version == \"3.9\"", "tomli-w (>=1,<2)", "tox (==4.23.2)", "twine (==6.0.1)", "typing-extensions (>=4.9.0)", "tzdata (>=2024.1) ; platform_system == \"Windows\"", "watchdog[watchmedo] (==6.0.0)", "wheel (==0.45.1)"]
@@ -1408,6 +1432,18 @@ files = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "1.3"
+description = "PKCS#5 v2.0 PBKDF2 Module"
+optional = false
+python-versions = "*"
+groups = ["main"]
+markers = "python_version == \"3.12\""
+files = [
+    {file = "pbkdf2-1.3.tar.gz", hash = "sha256:ac6397369f128212c43064a2b4878038dab78dab41875364554aaf2a684e6979"},
+]
+
+[[package]]
 name = "pigpio"
 version = "1.78"
 description = "Raspberry Pi GPIO module"
@@ -1418,6 +1454,112 @@ files = [
     {file = "pigpio-1.78-py2.py3-none-any.whl", hash = "sha256:81e46f640c4e6342881fa9bbe290dbcd4fc179619dc6591e57a9d4a084dc49fa"},
     {file = "pigpio-1.78.tar.gz", hash = "sha256:91efa50e4990649da97408a384782d6ccf58342fc59cdfe21ed7a42911569975"},
 ]
+
+[[package]]
+name = "pillow"
+version = "12.3.0"
+description = "Python Imaging Library (fork)"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "python_version == \"3.12\""
+files = [
+    {file = "pillow-12.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:6c0016e7b354317c4e9e525b937ac8596c38d2d232b419529b9cd7a1cd46e39a"},
+    {file = "pillow-12.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bcc33feacfaefce60c12fd500a277533bdc02b10a19f7f6d348763d8140bbba7"},
+    {file = "pillow-12.3.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5594fc43d548a7ed94949d139aa1341b270f1863f11cfd37f5a6c8b778a6b67f"},
+    {file = "pillow-12.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0606c8bf2cdefea14a43530f7657cbbb7ecf1c4222512492ef4a4434a9501ec"},
+    {file = "pillow-12.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:85f998ea1848bc6757289e739cfbdda3a04adfd58b02fc018ce54d754a5ce468"},
+    {file = "pillow-12.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:25b9b82bb22e6e2b3cd07b39c68b7b862001226cb3dff7130d1cb914121b39ed"},
+    {file = "pillow-12.3.0-cp310-cp310-win32.whl", hash = "sha256:37dc8f7bbb66efe481bb60defacef820c950c24713fb44962ed6aa2a50966de1"},
+    {file = "pillow-12.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:300557495eb45ebb8aec96c2da9c4be642fbf7cd937278b4013ba894ea8eb0eb"},
+    {file = "pillow-12.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:514435a37670e3e5e08f3945b68718b6ed329bb84367777e16f9f4dfe1e61a0f"},
+    {file = "pillow-12.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:00808c5e14ef63ac5161091d242999076604ff74b883423a11e5d7bbb38bf756"},
+    {file = "pillow-12.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:37d6d0a00072fd2948eb22bce7e1475f34569d90c87c59f7a2ec59541b77f7a6"},
+    {file = "pillow-12.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bcb46e2f9feff8d06323983bd83ed00c201fdcab3d74973e7072a889b3979fcd"},
+    {file = "pillow-12.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23d27a3e0307ec2244cc51e7287b919aa68d097504ebe19df4e76a98a3eea5bd"},
+    {file = "pillow-12.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4f883547d4b7f0495ebe7056b0cc2aea76094e7a4abc8e933540f3271df27d9c"},
+    {file = "pillow-12.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:236ff70b9312fb68943c703aa842ca6a758abfa45ac187a5e7c1452e96ef72b5"},
+    {file = "pillow-12.3.0-cp311-cp311-win32.whl", hash = "sha256:10e41f0fbf1eec8cfd234b8fe17a4caac7c9d0db4c204d3c173a8f9f6ef3232b"},
+    {file = "pillow-12.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:8e95e1385e4998ae9694eeaa4730ba5457ff61185b3a55e2e7bea0880aef452a"},
+    {file = "pillow-12.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:ebaea975e03d3141d9d3a507df75c9b3ec90fa9d2ffd07567b3a978d9d790b26"},
+    {file = "pillow-12.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ba09209fbe443b4acccebe845d8a138b89a8f4fbaeedd44953490b5315d5e965"},
+    {file = "pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffd0c5368496f41b0944be820fcb7a838aa6e623d250b01acf2643939c3f99d7"},
+    {file = "pillow-12.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9c7f76c0673154f044e9d78c8655fb4213f6ca31a836df48b40fe5d187717b9"},
+    {file = "pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91"},
+    {file = "pillow-12.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e491916b378fba47242221bb9ead245211b70d504f495d105d17b14a24b4907c"},
+    {file = "pillow-12.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0dd2064cbc55aaec028ef5fbb60fa47bb6c3e7918e07ff17935284b227a9d2df"},
+    {file = "pillow-12.3.0-cp312-cp312-win32.whl", hash = "sha256:dbce0b29841537a2fa4a214c2bbf14de3587c9680caa9b4e217568472490b28f"},
+    {file = "pillow-12.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2b55dd6b2a4c4b7d87ffa56bdb33fdc5fdb9a462173861a7bc097f17d91cb09"},
+    {file = "pillow-12.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:331b624368d4f1d069149002f25f44bc61c8919ce8ddb3c45bdad8f6e2d89510"},
+    {file = "pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:21900ce7ba264168cd50defae43cd75d25c833ad4ad6e73ffc5596d12e25ac89"},
+    {file = "pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4e8c2a84d977f50b9daed6eeaf3baef67d00d5d74d932288f02cb94518ee3ace"},
+    {file = "pillow-12.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:ae26d61dfa7a47befdc7572b521024e8745f3d809bd95ca9505a7bba9ef849ec"},
+    {file = "pillow-12.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7a743ff716f746fc19a9557f60dab1600d4613255f8a7aeb3cdde4db7eb15a66"},
+    {file = "pillow-12.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d69141514cc30b774ceea5e3ed3a6635c8d8a96edf664689b890f4089111fb35"},
+    {file = "pillow-12.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7401aebd7f581d7f83a439d87d474999317ee099218e5ad25d125290990ba65"},
+    {file = "pillow-12.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0847a763afefb695bc912d7c131e7e0632d4edc1d8698f58ddabec8e46b8b6d3"},
+    {file = "pillow-12.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:571b9fcb07b97ef3a492028fb3d2dc0993ca23a06138b0315286566d29ef718a"},
+    {file = "pillow-12.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:756c768d0c9c2955feb7a56c37ea24aea2e369f8d36a88da270b6a9f19e62b5e"},
+    {file = "pillow-12.3.0-cp313-cp313-win32.whl", hash = "sha256:a876864214e136f0eb367788dbd7df045f4806801518e2cfe9e13229cfe06d8f"},
+    {file = "pillow-12.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:1cca606cd25738df4ed873d5ad46bbdb3d83b5cbca291f6b4ff13a4df6b0bbe8"},
+    {file = "pillow-12.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:b629de27fda84b42cde7edef0d85f13b958b47f6e9bbcbba9b673c562a89bd8b"},
+    {file = "pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9cf95fe4d0f84c82d282745d9bb08ad9f926efa00be4697e767b814ce40d4330"},
+    {file = "pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:8728f216dcdb6e6d555cf971cb34076139ad74b31fc2c14da4fafc741c5f6217"},
+    {file = "pillow-12.3.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a45650e8ce7fafffd731db8550230db6b0d306d181a90b67d3e6bca2f1990930"},
+    {file = "pillow-12.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ba54cfebe86920a559a7c4d6b9050791c20513650a1952ebe3368c7dc70306f8"},
+    {file = "pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e158cb00350dc278f3b91551101aa7d12415a66ebf2c91d8d5ac14e56ddd3ad0"},
+    {file = "pillow-12.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9aeb04d6aef139de265b29683e119b638208f88cf73cdd1658aa07221165321"},
+    {file = "pillow-12.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:251bf95b67017e27b13d82f5b326234ca62d70f9cf4c2b9032de2358a3b12c7b"},
+    {file = "pillow-12.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fe3cca2e4e8a592be0f269a1ca4835c25199d9f3ce815c8491048f785b0a0198"},
+    {file = "pillow-12.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:23aceaa007d6172b02c277f0cd359c79492bbb14f7072b4ede9fbcaf20648130"},
+    {file = "pillow-12.3.0-cp314-cp314-win32.whl", hash = "sha256:af8d94b0db561cf68b88a267c5c44b49e134f525d0dc2cb7ed413a66bc23559a"},
+    {file = "pillow-12.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:fdafc9cce40277e0f7a0feabce0ee50dd2fa1800f3b38015e51296b5e814048d"},
+    {file = "pillow-12.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:e91206ee562682b51b98ef4b26a6ef48fd84e15fd4c4bc5ec768eb641d206838"},
+    {file = "pillow-12.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:164b31cd1a0490ab6efae01aa5df49da7061be0af1b30e035b6e9a1bfe34ee6e"},
+    {file = "pillow-12.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5afb51d599ea772b8365ae807ae557f18bccfe46ab261fd1c2a9ed700fc6eb17"},
+    {file = "pillow-12.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3edce1d53195db527e0191f84b71d02022de0540bf43a16ed734ed7537b07385"},
+    {file = "pillow-12.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf16ba1b4d0b6b7c8e534936632270cf70eb00dbe09005bc345b2677b726855c"},
+    {file = "pillow-12.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:24870b09b224f7ae3c39ed07d10e819d06f8720bc551847b1d623832b5b0e28d"},
+    {file = "pillow-12.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:30f2aa603c41533cc25c05acd0da21636e84a315768feb631c937177db558931"},
+    {file = "pillow-12.3.0-cp314-cp314t-win32.whl", hash = "sha256:4b0a7fe987b14c31ebda6083f74f22b561fd3739bc0ac51e019622e3d72668c7"},
+    {file = "pillow-12.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:962864dc93511324d51ddbb5b9f8731bf71675b93ca612a07441896f4688fb8c"},
+    {file = "pillow-12.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0740a512dc522224c77d9aa5a8d70d8b7d73fb91f2c21125d8d025d3b8990e45"},
+    {file = "pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:0feb2e9d6ad6c9e3c06effe9d00f3f1e618a6643273576b016f591e9315a7139"},
+    {file = "pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:9e881fca225083806662a5c43d627d215f258ff43c890f831966c7d7ba9c7402"},
+    {file = "pillow-12.3.0-cp315-cp315-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:4998562bf62a445225f22e07c896bb04b35b1b1f2eb6d760584c9c51d7a5f78c"},
+    {file = "pillow-12.3.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:dc624f6bc473dacdf7ef7eb8678d0d08edf15cd94fad6ae5c7d6cc67a4e4902f"},
+    {file = "pillow-12.3.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:71d6097b330eea8fd15097780c8e89cb1a8ce7838669f48c5bacd6f663dd4701"},
+    {file = "pillow-12.3.0-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28ce87c5ab450a9dd970b52e5aca5fe63ed432d18a2eaddd1979a00a1ba24ace"},
+    {file = "pillow-12.3.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b02afb9b97f65fbca5f31db6a2a3ba21aa93030225f150fa3f249717e938fb4"},
+    {file = "pillow-12.3.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:1182d52bc2d5e5d7d0949503aa7e36d12f42205dc287e4883f407b1988820d39"},
+    {file = "pillow-12.3.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e795b7eb908249c4e43c7c99fac7c2c75dab0c43566e37db472a355f63693d71"},
+    {file = "pillow-12.3.0-cp315-cp315-win32.whl", hash = "sha256:57b3d78c95ba9059768b10e28b813002261d3f3dfc55cc48b0c988f625175827"},
+    {file = "pillow-12.3.0-cp315-cp315-win_amd64.whl", hash = "sha256:fa4ecea169a355be7a3ade2c783e2ed12f0e40d2c5621cda8b3297faf7fbb9f5"},
+    {file = "pillow-12.3.0-cp315-cp315-win_arm64.whl", hash = "sha256:877c3f311ff35410f690861c4409e7ccbf0cd2f878e50628a28e5a0bb689e658"},
+    {file = "pillow-12.3.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:e9871b1ffbfa9656b60aeee92ed5136a5742696006fa322b29ea3d8da0ecc9cf"},
+    {file = "pillow-12.3.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:53aa02d20d10c3d814d536aa4e5ac9b84ca0ff5a88377963b085ad6822f93e64"},
+    {file = "pillow-12.3.0-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:446c34dcc4324b084a53b705127dc15717b22c5e140ae0a3c38349d4efec071e"},
+    {file = "pillow-12.3.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf1845d02ad822a369a49f2bb9345b1614744267682e7a03527dc3bf6eea1777"},
+    {file = "pillow-12.3.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:186941b6aef820ad110fb01fb06eb925374dc3a21b17e37ec9a53b250c6fe2d1"},
+    {file = "pillow-12.3.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:f13c32a3abd6079a66d9526e18dad9b6d280384d49d7c54040cd57b6424041d9"},
+    {file = "pillow-12.3.0-cp315-cp315t-win32.whl", hash = "sha256:1657923d2d45afb66526e5b933e5b3052e6bdea196c90d3abb2424e18c77dae8"},
+    {file = "pillow-12.3.0-cp315-cp315t-win_amd64.whl", hash = "sha256:8cd2f7bdda092d99c9fc2fb7391354f306d01443d22785d0cbfafa2e2c8bb418"},
+    {file = "pillow-12.3.0-cp315-cp315t-win_arm64.whl", hash = "sha256:06ff022112bc9cbf83b60f8e028d94ad87b60621706487e65f673de61610ab59"},
+    {file = "pillow-12.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:b3c777e849237620b022f7f297dd67705f9f5cf1685f09f02e46f93e92725468"},
+    {file = "pillow-12.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b343699e8308bdc51978310e1c959c584e7869cc8c40780058c87da7781a1e94"},
+    {file = "pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbd139c8447d25dd750ab79ee274cc5e1fe80fc56340ab10b18a195e1b6eca3e"},
+    {file = "pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7e480451b9fa137494bccd3a7d69adbe8ac65a87d97be61e11f1b1050a5bac3"},
+    {file = "pillow-12.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:04f01d28a6aaff387bf842a13be313df23ba0597a44f1a976c9feb3c6ff4711a"},
+    {file = "pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce"},
+]
+
+[package.extras]
+docs = ["furo", "olefile", "sphinx (>=8.2)", "sphinx-autobuild", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxext-opengraph"]
+fpx = ["olefile"]
+mic = ["olefile"]
+test-arrow = ["arro3-compute", "arro3-core", "nanoarrow", "pyarrow"]
+tests = ["coverage (>=7.4.2)", "defusedxml", "markdown2", "olefile", "packaging", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "setuptools", "trove-classifiers (>=2024.10.12)"]
+xmp = ["defusedxml"]
 
 [[package]]
 name = "platformdirs"
@@ -1591,6 +1733,18 @@ files = [
     {file = "protobuf-6.32.1-cp39-cp39-win_amd64.whl", hash = "sha256:d0975d0b2f3e6957111aa3935d08a0eb7e006b1505d825f862a1fffc8348e122"},
     {file = "protobuf-6.32.1-py3-none-any.whl", hash = "sha256:2601b779fc7d32a866c6b4404f9d42a3f67c5b9f3f15b4db3cccabe06b95c346"},
     {file = "protobuf-6.32.1.tar.gz", hash = "sha256:ee2469e4a021474ab9baafea6cd070e5bf27c7d29433504ddea1a4ee5850f68d"},
+]
+
+[[package]]
+name = "pyaes"
+version = "1.6.1"
+description = "Pure-Python Implementation of the AES block-cipher and common modes of operation"
+optional = false
+python-versions = "*"
+groups = ["main"]
+markers = "python_version == \"3.12\""
+files = [
+    {file = "pyaes-1.6.1.tar.gz", hash = "sha256:02c1b1405c38d3c370b085fb952dd8bea3fadcee6411ad99f312cc129c536d8f"},
 ]
 
 [[package]]
@@ -1949,6 +2103,19 @@ files = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.8.4"
+description = "A modern CSS selector implementation for Beautiful Soup."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "python_version == \"3.12\""
+files = [
+    {file = "soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65"},
+    {file = "soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e"},
+]
+
+[[package]]
 name = "todoist-api-python"
 version = "3.2.1"
 description = "Official Python SDK for the Todoist API."
@@ -2069,12 +2236,25 @@ version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["dev"]
+markers = "python_version >= \"3.13\""
 files = [
     {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
-markers = {main = "python_version == \"3.12\""}
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+description = "Backported and Experimental Type Hints for Python 3.9+"
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "dev"]
+markers = "python_version == \"3.12\""
+files = [
+    {file = "typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"},
+    {file = "typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5"},
+]
 
 [[package]]
 name = "tzdata"
@@ -2270,4 +2450,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "c9b385e4bb5076f4bfe8778450bfc73c609ba122a27c4a5fcac3d6174a786c30"
+content-hash = "9751165ef2d868b6ef340dcc8d6c5ca80a238f84536787b064f5290a6a1ffe8b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ types-requests = "^2.32.0.20240602"
 google-auth = "*"
 google-auth-oauthlib = "*"
 google-api-python-client = "*"
+audible = {version = "^0.10.0", python = ">=3.12,<3.13"}
 
 [tool.poetry.group.test.dependencies]
 pytest = "*"

--- a/src/spanreed/__main__.py
+++ b/src/spanreed/__main__.py
@@ -22,6 +22,8 @@ from spanreed.plugins.withings import WithingsPlugin
 from spanreed.plugins.gmail_monitor import GmailMonitorPlugin
 from spanreed.plugins.hevy import HevyPlugin
 from spanreed.plugins.googlefit import GoogleFitPlugin
+from spanreed.apis.audible import AudiblePlugin
+from spanreed.plugins.book_progress import BookProgressPlugin
 
 
 def setup_logger() -> None:
@@ -58,6 +60,8 @@ def load_plugins() -> List[Plugin]:
         GmailMonitorPlugin(),
         HevyPlugin(),
         GoogleFitPlugin(),
+        AudiblePlugin(),
+        BookProgressPlugin(),
     ]
 
     return core_plugins + optional_plugins
@@ -93,9 +97,7 @@ async def _notify_plugin_failure(plugin: Plugin, error: BaseException) -> None:
     for user in await plugin.get_users():
         try:
             bot: TelegramBotApi = await TelegramBotApi.for_user(user)
-            await bot.send_message(
-                f"Plugin '{plugin.name()}' has crashed: {error}"
-            )
+            await bot.send_message(f"Plugin '{plugin.name()}' has crashed: {error}")
         except Exception:
             logging.exception(
                 f"Failed to notify user {user.id} about "

--- a/src/spanreed/apis/audible.py
+++ b/src/spanreed/apis/audible.py
@@ -1,0 +1,135 @@
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import audible
+
+from spanreed.plugin import Plugin
+from spanreed.user import User
+from spanreed.apis.telegram_bot import TelegramBotApi
+
+
+MARKETPLACE_LOCALE = "us"
+
+
+@dataclass
+class UserConfig:
+    # The `Authenticator.to_dict()` blob (tokens, device info, locale).
+    auth: dict
+
+
+@dataclass
+class AudibleBook:
+    asin: str
+    title: str
+    subtitle: str | None
+    percent_complete: float
+    is_finished: bool
+
+
+class AudiblePlugin(Plugin):
+    @classmethod
+    def name(cls) -> str:
+        return "Audible"
+
+    @classmethod
+    def has_user_config(cls) -> bool:
+        return True
+
+    @classmethod
+    def get_config_class(cls) -> type[UserConfig]:
+        return UserConfig
+
+    @classmethod
+    async def ask_for_user_config(cls, user: User) -> None:
+        authenticator = await AudibleApi.authenticate(user)
+        await cls.set_config(user, UserConfig(auth=authenticator.to_dict()))
+
+
+class AudibleApi:
+    def __init__(self, authenticator: audible.Authenticator) -> None:
+        self._auth = authenticator
+        self._logger = logging.getLogger(__name__)
+
+    @classmethod
+    async def for_user(cls, user: User) -> "AudibleApi":
+        user_config: UserConfig = await AudiblePlugin.get_config(user)
+        # `from_dict` mutates the dict it's given, so pass a copy to keep the
+        # stored config intact.
+        authenticator = audible.Authenticator.from_dict(dict(user_config.auth))
+        if authenticator.access_token_expired:
+            # The refresh does blocking I/O (httpx sync client).
+            await asyncio.to_thread(authenticator.refresh_access_token)
+            await AudiblePlugin.set_config(
+                user, UserConfig(auth=authenticator.to_dict())
+            )
+        return cls(authenticator)
+
+    @classmethod
+    async def authenticate(cls, user: User) -> audible.Authenticator:
+        """Register a new Audible "device" for this user.
+
+        Amazon login happens in the user's own browser: we send them the
+        login URL over Telegram, and they paste back the URL of the page
+        they land on after logging in (an error page whose URL contains
+        the authorization code).
+        """
+        bot: TelegramBotApi = await TelegramBotApi.for_user(user)
+        loop = asyncio.get_running_loop()
+
+        def login_url_callback(login_url: str) -> str:
+            # Called from the worker thread `from_login_external` runs in;
+            # bridge back into the event loop for the Telegram interaction.
+            return asyncio.run_coroutine_threadsafe(
+                cls._request_redirect_url_from_user(bot, login_url), loop
+            ).result()
+
+        return await asyncio.to_thread(
+            lambda: audible.Authenticator.from_login_external(
+                locale=MARKETPLACE_LOCALE,
+                login_url_callback=login_url_callback,
+            )
+        )
+
+    @staticmethod
+    async def _request_redirect_url_from_user(
+        bot: TelegramBotApi, login_url: str
+    ) -> str:
+        await bot.send_message(
+            f'<b><a href="{login_url}">Click here to log in to Amazon</a></b>'
+            "\nAfter logging in, you'll land on an error page — that's"
+            " expected.",
+        )
+        return await bot.request_user_input(
+            "Paste the full URL of the page you landed on"
+            " (it contains the authorization code):"
+        )
+
+    async def get_library(self) -> list[AudibleBook]:
+        params: dict[str, Any] = {
+            "num_results": 1000,
+            "response_groups": (
+                "product_desc,product_attrs,percent_complete,is_finished"
+            ),
+        }
+        async with audible.AsyncClient(auth=self._auth) as client:
+            response = await client.get("1.0/library", **params)
+
+        books: list[AudibleBook] = []
+        for item in response["items"]:
+            asin: str | None = item.get("asin")
+            title: str | None = item.get("title")
+            if not asin or not title:
+                continue
+            books.append(
+                AudibleBook(
+                    asin=asin,
+                    title=title,
+                    subtitle=item.get("subtitle"),
+                    percent_complete=float(item.get("percent_complete") or 0),
+                    is_finished=bool(item.get("is_finished")),
+                )
+            )
+        self._logger.info(f"Fetched {len(books)} books from Audible library")
+        return books

--- a/src/spanreed/apis/obsidian.py
+++ b/src/spanreed/apis/obsidian.py
@@ -212,7 +212,10 @@ class ObsidianApi:
         )
 
     async def set_value_of_property(
-        self, filepath: str, property_name: str, value: str | list[str]
+        self,
+        filepath: str,
+        property_name: str,
+        value: str | int | float | list[str],
     ) -> None:
         await self._send_request(
             "modify-property",

--- a/src/spanreed/plugins/book_progress.py
+++ b/src/spanreed/plugins/book_progress.py
@@ -1,0 +1,227 @@
+import asyncio
+import datetime
+import difflib
+import re
+from typing import Any
+
+from spanreed.plugin import Plugin
+from spanreed.user import User
+from spanreed.apis.audible import AudibleApi, AudibleBook, AudiblePlugin
+from spanreed.apis.obsidian import ObsidianApi, ObsidianPlugin
+from spanreed.apis.telegram_bot import TelegramBotApi, PluginCommand
+
+
+SYNC_INTERVAL = datetime.timedelta(hours=1)
+LINK_SNOOZE_DURATION = datetime.timedelta(hours=24)
+FINISH_THRESHOLD_PERCENT = 99
+MATCH_SCORE_CUTOFF = 0.5
+MAX_MATCH_CANDIDATES = 3
+# Telegram inline keyboard buttons get visually truncated around this length.
+MAX_CHOICE_LABEL_LENGTH = 60
+
+
+def _normalize_title(title: str) -> str:
+    return re.sub(r"[^a-z0-9 ]", "", title.lower()).strip()
+
+
+def _match_score(note_title: str, book: AudibleBook) -> float:
+    """Similarity between a note title and an Audible book title.
+
+    Audible titles often carry series suffixes after a colon (e.g.
+    "The Way of Kings: The Stormlight Archive, Book 1"), so the main part
+    before the colon is scored as well and the best score wins.
+    """
+    note = _normalize_title(note_title)
+    scores = []
+    for candidate in (book.title, book.title.split(":")[0]):
+        scores.append(
+            difflib.SequenceMatcher(None, note, _normalize_title(candidate)).ratio()
+        )
+    return max(scores)
+
+
+def find_match_candidates(
+    note_title: str, books: list[AudibleBook]
+) -> list[AudibleBook]:
+    scored = [(book, _match_score(note_title, book)) for book in books]
+    matches = [(book, score) for book, score in scored if score >= MATCH_SCORE_CUTOFF]
+    matches.sort(key=lambda pair: pair[1], reverse=True)
+    return [book for book, _ in matches[:MAX_MATCH_CANDIDATES]]
+
+
+class BookProgressPlugin(Plugin):
+    @classmethod
+    def name(cls) -> str:
+        return "Audible Book Progress"
+
+    @classmethod
+    def get_prerequisites(cls) -> list[type[Plugin]]:
+        return [AudiblePlugin, ObsidianPlugin]
+
+    async def run(self) -> None:
+        await TelegramBotApi.register_command(
+            self,
+            PluginCommand(text="Sync book progress", callback=self._sync_now),
+        )
+        await super().run()
+
+    async def run_for_user(self, user: User) -> None:
+        while True:
+            await self._sync(user)
+            await asyncio.sleep(SYNC_INTERVAL.total_seconds())
+
+    async def _sync_now(self, user: User) -> None:
+        """Manually triggered sync via the Telegram command."""
+        bot: TelegramBotApi = await TelegramBotApi.for_user(user)
+        await bot.notify("Syncing Audible book progress…")
+        updated = await self._sync(user)
+        if updated == 0:
+            await bot.notify("No book progress changes found.")
+
+    async def _sync(self, user: User) -> int:
+        """Sync Audible progress onto currently-reading book notes.
+
+        Returns the number of notes whose progress was updated.
+        """
+        obsidian: ObsidianApi = await ObsidianApi.for_user(user)
+        notes = await obsidian.query_dataview(
+            """
+        table title, asin
+        from #book
+        where status = "reading"
+        """
+        )
+        if not notes:
+            return 0
+
+        audible_api: AudibleApi = await AudibleApi.for_user(user)
+        library: list[AudibleBook] = await audible_api.get_library()
+        library_by_asin = {book.asin: book for book in library}
+
+        updated = 0
+        for note in notes:
+            note_path: str = note.file["path"]
+            book: AudibleBook | None
+            if note.asin:
+                book = library_by_asin.get(note.asin)
+                if book is None:
+                    self._logger.warning(
+                        f"Note {note_path} has asin {note.asin} that isn't"
+                        " in the Audible library; skipping."
+                    )
+                    continue
+            else:
+                book = await self._link_note_to_book(user, obsidian, note, library)
+                if book is None:
+                    continue
+
+            if await self._update_progress(obsidian, note_path, book):
+                updated += 1
+            await self._maybe_prompt_finished(user, obsidian, note_path, book)
+        return updated
+
+    def _note_title(self, note: Any) -> str:
+        if note.title:
+            return str(note.title)
+        # Fall back to the note's filename.
+        note_path: str = note.file["path"]
+        return note_path.rsplit("/", 1)[-1].removesuffix(".md")
+
+    async def _link_note_to_book(
+        self,
+        user: User,
+        obsidian: ObsidianApi,
+        note: Any,
+        library: list[AudibleBook],
+    ) -> AudibleBook | None:
+        """Fuzzy-match a note to an Audible book, verified by the user.
+
+        The chosen ASIN is persisted on the note so matching is exact from
+        then on. Books marked "Not on Audible" are never asked about again;
+        "Ask me later" snoozes the question for a day.
+        """
+        note_path: str = note.file["path"]
+        if await self.get_user_data(user, f"not-audible:{note_path}"):
+            return None
+        snoozed_at: str | None = await self.get_user_data(
+            user, f"link-snooze:{note_path}"
+        )
+        if snoozed_at is not None and (
+            datetime.datetime.now()
+            < datetime.datetime.fromisoformat(snoozed_at) + LINK_SNOOZE_DURATION
+        ):
+            return None
+
+        title = self._note_title(note)
+        candidates = find_match_candidates(title, library)
+        if not candidates:
+            self._logger.info(f"No Audible match candidates for {note_path}; snoozing.")
+            await self._snooze_link(user, note_path)
+            return None
+
+        bot: TelegramBotApi = await TelegramBotApi.for_user(user)
+        async with bot.user_interaction():
+            choice = await bot.request_user_choice(
+                f'Which Audible book is "{title}"?',
+                [book.title[:MAX_CHOICE_LABEL_LENGTH] for book in candidates]
+                + ["Not on Audible", "Ask me later"],
+            )
+        if choice < len(candidates):
+            book = candidates[choice]
+            await obsidian.set_value_of_property(note_path, "asin", book.asin)
+            return book
+        if choice == len(candidates):  # Not on Audible
+            await self.set_user_data(user, f"not-audible:{note_path}", "true")
+        else:  # Ask me later
+            await self._snooze_link(user, note_path)
+        return None
+
+    async def _snooze_link(self, user: User, note_path: str) -> None:
+        await self.set_user_data(
+            user,
+            f"link-snooze:{note_path}",
+            datetime.datetime.now().isoformat(),
+        )
+
+    async def _update_progress(
+        self, obsidian: ObsidianApi, note_path: str, book: AudibleBook
+    ) -> bool:
+        progress = round(book.percent_complete)
+        current = await obsidian.get_property(note_path, "progress")
+        if current == progress:
+            return False
+        await obsidian.set_value_of_property(note_path, "progress", progress)
+        return True
+
+    async def _maybe_prompt_finished(
+        self,
+        user: User,
+        obsidian: ObsidianApi,
+        note_path: str,
+        book: AudibleBook,
+    ) -> None:
+        """Offer (once) to mark a note as read when Audible says it's done."""
+        if book.percent_complete < FINISH_THRESHOLD_PERCENT and not book.is_finished:
+            return
+        if await self.get_user_data(user, f"finish-prompted:{book.asin}"):
+            return
+
+        bot: TelegramBotApi = await TelegramBotApi.for_user(user)
+        async with bot.user_interaction():
+            choice = await bot.request_user_choice(
+                f'Looks like you finished "{book.title}" on Audible.\n'
+                "Mark it as read?",
+                ["Yes", "No"],
+            )
+        await self.set_user_data(
+            user,
+            f"finish-prompted:{book.asin}",
+            datetime.datetime.now().isoformat(),
+        )
+        if choice == 0:
+            await obsidian.set_value_of_property(note_path, "status", "read")
+            await obsidian.set_value_of_property(
+                note_path,
+                "finish-date",
+                datetime.date.today().strftime("%Y-%m-%d"),
+            )

--- a/src/spanreed/plugins/book_progress_test.py
+++ b/src/spanreed/plugins/book_progress_test.py
@@ -1,0 +1,282 @@
+import asyncio
+import datetime
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from spanreed.apis.audible import AudibleBook
+from spanreed.plugin import Plugin
+from spanreed.plugins.book_progress import (
+    BookProgressPlugin,
+    find_match_candidates,
+)
+from spanreed.test_utils import (
+    mock_user_find_by_id,
+    patch_obsidian,
+    patch_redis,
+    patch_telegram_bot,
+)
+
+
+def _book(
+    asin: str,
+    title: str,
+    percent_complete: float = 0.0,
+    is_finished: bool = False,
+) -> AudibleBook:
+    return AudibleBook(
+        asin=asin,
+        title=title,
+        subtitle=None,
+        percent_complete=percent_complete,
+        is_finished=is_finished,
+    )
+
+
+def _note(path: str, title: str | None, asin: str | None) -> SimpleNamespace:
+    return SimpleNamespace(title=title, asin=asin, file={"path": path})
+
+
+def test_name() -> None:
+    Plugin.reset_registry()
+    plugin = BookProgressPlugin()
+
+    assert plugin.name() == "Audible Book Progress"
+    assert plugin.canonical_name() == "audible-book-progress"
+
+
+def test_find_match_candidates_handles_subtitle_suffix() -> None:
+    books = [
+        _book("B1", "The Way of Kings: The Stormlight Archive, Book 1"),
+        _book("B2", "Project Hail Mary"),
+    ]
+
+    candidates = find_match_candidates("The Way of Kings", books)
+
+    assert [book.asin for book in candidates] == ["B1"]
+
+
+def test_find_match_candidates_orders_best_first() -> None:
+    books = [
+        _book("B1", "The Colour of Magic"),
+        _book("B2", "A Colour of Magic Companion"),
+    ]
+
+    candidates = find_match_candidates("The Colour of Magic", books)
+
+    assert [book.asin for book in candidates] == ["B1", "B2"]
+
+
+def test_find_match_candidates_no_match() -> None:
+    books = [_book("B1", "Project Hail Mary")]
+
+    assert find_match_candidates("The Way of Kings", books) == []
+
+
+@patch("spanreed.plugins.book_progress.AudibleApi", autospec=True)
+@patch_obsidian("spanreed.plugins.book_progress")
+@patch_telegram_bot("spanreed.plugins.book_progress")
+@patch_redis
+def test_sync_updates_progress_for_linked_note(
+    mock_redis: Any,
+    mock_bot: AsyncMock,
+    mock_obsidian: AsyncMock,
+    mock_audible: AsyncMock,
+) -> None:
+    Plugin.reset_registry()
+    plugin = BookProgressPlugin()
+
+    mock_obsidian.query_dataview.return_value = [
+        _note("Books/The Way of Kings.md", "The Way of Kings", "B1")
+    ]
+    mock_audible.for_user = AsyncMock(return_value=mock_audible)
+    mock_audible.get_library = AsyncMock(
+        return_value=[_book("B1", "The Way of Kings", percent_complete=42.4)]
+    )
+    mock_obsidian.get_property.return_value = None
+
+    user = mock_user_find_by_id(4)
+    updated = asyncio.run(plugin._sync(user))
+
+    assert updated == 1
+    mock_obsidian.set_value_of_property.assert_awaited_once_with(
+        "Books/The Way of Kings.md", "progress", 42
+    )
+    mock_bot.request_user_choice.assert_not_awaited()
+
+
+@patch("spanreed.plugins.book_progress.AudibleApi", autospec=True)
+@patch_obsidian("spanreed.plugins.book_progress")
+@patch_telegram_bot("spanreed.plugins.book_progress")
+@patch_redis
+def test_sync_skips_unchanged_progress(
+    mock_redis: Any,
+    mock_bot: AsyncMock,
+    mock_obsidian: AsyncMock,
+    mock_audible: AsyncMock,
+) -> None:
+    Plugin.reset_registry()
+    plugin = BookProgressPlugin()
+
+    mock_obsidian.query_dataview.return_value = [
+        _note("Books/The Way of Kings.md", "The Way of Kings", "B1")
+    ]
+    mock_audible.for_user = AsyncMock(return_value=mock_audible)
+    mock_audible.get_library = AsyncMock(
+        return_value=[_book("B1", "The Way of Kings", percent_complete=42.4)]
+    )
+    mock_obsidian.get_property.return_value = 42
+
+    user = mock_user_find_by_id(4)
+    updated = asyncio.run(plugin._sync(user))
+
+    assert updated == 0
+    mock_obsidian.set_value_of_property.assert_not_awaited()
+
+
+@patch("spanreed.plugins.book_progress.AudibleApi", autospec=True)
+@patch_obsidian("spanreed.plugins.book_progress")
+@patch_telegram_bot("spanreed.plugins.book_progress")
+@patch_redis
+def test_unlinked_note_verification_persists_asin(
+    mock_redis: Any,
+    mock_bot: AsyncMock,
+    mock_obsidian: AsyncMock,
+    mock_audible: AsyncMock,
+) -> None:
+    Plugin.reset_registry()
+    plugin = BookProgressPlugin()
+
+    mock_redis.get.return_value = None  # No snooze/not-audible markers.
+    mock_obsidian.query_dataview.return_value = [
+        _note("Books/Project Hail Mary.md", "Project Hail Mary", None)
+    ]
+    mock_audible.for_user = AsyncMock(return_value=mock_audible)
+    mock_audible.get_library = AsyncMock(
+        return_value=[
+            _book("B1", "The Way of Kings"),
+            _book("B2", "Project Hail Mary", percent_complete=10.0),
+        ]
+    )
+    mock_obsidian.get_property.return_value = None
+    # The only candidate offered should be "Project Hail Mary"; pick it.
+    mock_bot.request_user_choice.return_value = 0
+
+    user = mock_user_find_by_id(4)
+    updated = asyncio.run(plugin._sync(user))
+
+    assert updated == 1
+    mock_obsidian.set_value_of_property.assert_any_await(
+        "Books/Project Hail Mary.md", "asin", "B2"
+    )
+    mock_obsidian.set_value_of_property.assert_any_await(
+        "Books/Project Hail Mary.md", "progress", 10
+    )
+
+
+@patch("spanreed.plugins.book_progress.AudibleApi", autospec=True)
+@patch_obsidian("spanreed.plugins.book_progress")
+@patch_telegram_bot("spanreed.plugins.book_progress")
+@patch_redis
+def test_not_on_audible_choice_is_remembered(
+    mock_redis: Any,
+    mock_bot: AsyncMock,
+    mock_obsidian: AsyncMock,
+    mock_audible: AsyncMock,
+) -> None:
+    Plugin.reset_registry()
+    plugin = BookProgressPlugin()
+
+    mock_redis.get.return_value = None
+    mock_obsidian.query_dataview.return_value = [
+        _note("Books/Project Hail Mary.md", "Project Hail Mary", None)
+    ]
+    mock_audible.for_user = AsyncMock(return_value=mock_audible)
+    mock_audible.get_library = AsyncMock(
+        return_value=[_book("B2", "Project Hail Mary")]
+    )
+    # One candidate, so index 1 is "Not on Audible".
+    mock_bot.request_user_choice.return_value = 1
+
+    user = mock_user_find_by_id(4)
+    updated = asyncio.run(plugin._sync(user))
+
+    assert updated == 0
+    mock_obsidian.set_value_of_property.assert_not_awaited()
+    not_audible_keys = [
+        call.args[0]
+        for call in mock_redis.set.await_args_list
+        if "not-audible:Books/Project Hail Mary.md" in call.args[0]
+    ]
+    assert len(not_audible_keys) == 1
+
+
+@patch("spanreed.plugins.book_progress.AudibleApi", autospec=True)
+@patch_obsidian("spanreed.plugins.book_progress")
+@patch_telegram_bot("spanreed.plugins.book_progress")
+@patch_redis
+def test_finished_book_prompts_and_marks_read(
+    mock_redis: Any,
+    mock_bot: AsyncMock,
+    mock_obsidian: AsyncMock,
+    mock_audible: AsyncMock,
+) -> None:
+    Plugin.reset_registry()
+    plugin = BookProgressPlugin()
+
+    mock_redis.get.return_value = None  # Not prompted before.
+    mock_obsidian.query_dataview.return_value = [
+        _note("Books/The Way of Kings.md", "The Way of Kings", "B1")
+    ]
+    mock_audible.for_user = AsyncMock(return_value=mock_audible)
+    mock_audible.get_library = AsyncMock(
+        return_value=[_book("B1", "The Way of Kings", percent_complete=100.0)]
+    )
+    mock_obsidian.get_property.return_value = 98
+    mock_bot.request_user_choice.return_value = 0  # Yes, mark as read.
+
+    user = mock_user_find_by_id(4)
+    asyncio.run(plugin._sync(user))
+
+    mock_obsidian.set_value_of_property.assert_any_await(
+        "Books/The Way of Kings.md", "progress", 100
+    )
+    mock_obsidian.set_value_of_property.assert_any_await(
+        "Books/The Way of Kings.md", "status", "read"
+    )
+    mock_obsidian.set_value_of_property.assert_any_await(
+        "Books/The Way of Kings.md",
+        "finish-date",
+        datetime.date.today().strftime("%Y-%m-%d"),
+    )
+
+
+@patch("spanreed.plugins.book_progress.AudibleApi", autospec=True)
+@patch_obsidian("spanreed.plugins.book_progress")
+@patch_telegram_bot("spanreed.plugins.book_progress")
+@patch_redis
+def test_finish_prompt_only_happens_once(
+    mock_redis: Any,
+    mock_bot: AsyncMock,
+    mock_obsidian: AsyncMock,
+    mock_audible: AsyncMock,
+) -> None:
+    Plugin.reset_registry()
+    plugin = BookProgressPlugin()
+
+    # A previous prompt was recorded for this book.
+    mock_redis.get.return_value = "2026-07-01T00:00:00"
+    mock_obsidian.query_dataview.return_value = [
+        _note("Books/The Way of Kings.md", "The Way of Kings", "B1")
+    ]
+    mock_audible.for_user = AsyncMock(return_value=mock_audible)
+    mock_audible.get_library = AsyncMock(
+        return_value=[_book("B1", "The Way of Kings", percent_complete=100.0)]
+    )
+    mock_obsidian.get_property.return_value = 100
+
+    user = mock_user_find_by_id(4)
+    asyncio.run(plugin._sync(user))
+
+    mock_bot.request_user_choice.assert_not_awaited()
+    mock_obsidian.set_value_of_property.assert_not_awaited()


### PR DESCRIPTION
## What

Automatically syncs Audible listening progress onto Obsidian book notes.

- **New `AudiblePlugin`** ([apis/audible.py](../blob/audible-book-progress/src/spanreed/apis/audible.py)): owns the Audible credentials so future Audible features can reuse them. Registration uses the [mkb79/audible](https://github.com/mkb79/Audible) external-login flow — the login URL is sent over Telegram, the user logs in in their own browser and pastes back the redirect URL, so Spanreed never handles the Amazon password. The `Authenticator.to_dict()` token blob is stored in Redis via the standard plugin-config mechanism and auto-refreshes on expiry.
- **New `BookProgressPlugin`** ("Audible Book Progress", [plugins/book_progress.py](../blob/audible-book-progress/src/spanreed/plugins/book_progress.py)): hourly sync loop plus a manual "Sync book progress" Telegram command. Prerequisites: Audible + Obsidian plugins.

## Behavior

- Only touches `#book` notes with `status: reading` (Dataview query).
- Writes a `progress` percentage property, only when the rounded value changed.
- Notes without an `asin` property are fuzzy-matched by title (stdlib `difflib`, handles Audible's ": Series, Book N" suffixes); the user verifies the match via Telegram and the ASIN is persisted onto the note's frontmatter for exact matching thereafter. "Not on Audible" is remembered permanently; "Ask me later" snoozes for 24h.
- At ≥99% (or Audible's `is_finished` flag), prompts once whether to set `status: read` + `finish-date` — never automatic.

## Notes for review

- The `audible` package caps Python at <3.13, so it's added with a `>=3.12,<3.13` marker (server and CI both run 3.12).
- `ObsidianApi.set_value_of_property`'s annotation widened to accept numbers — existing callers (Withings, Google Fit) already pass them.
- The Audible API is unofficial (same one the mobile apps use); the auth handshake can only be exercised with a real account, which happens on first plugin registration after deploy.

## Testing

- 9 new tests in `book_progress_test.py` (matching, progress write/skip, ASIN persistence, "Not on Audible" memory, finish prompt + once-only marker); full suite 95/95 green.
- mypy and black clean on the new files.
