### PR TITLE
Telegram: route all sends through a per-user paced dispatcher

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -62,7 +62,7 @@ scanner noise AND very chatty Obsidian watchdog DEBUG lines — filter both.
 Note the loop var is `mres`, not `status` (zsh read-only).
 
 ```
-ssh -o BatchMode=yes root@spanreed.ink 'deadline=$((SECONDS+90)); mres=TIMEOUT; while [ $SECONDS -lt $deadline ]; do log=$(journalctl -u spanreed -S -3m --no-pager); if printf "%s" "$log" | grep -qE "ModuleNotFoundError|ImportError"; then mres=FATAL; break; fi; if printf "%s" "$log" | grep -q "Started polling"; then mres=OK; break; fi; sleep 3; done; echo "MONITOR_RESULT=$mres"; echo "SERVICE=$(systemctl is-active spanreed)"; echo "=== startup markers ==="; journalctl -u spanreed -S -3m --no-pager | grep -iE "Running [0-9]+ plugins|Started polling|outbound-message consumer|crashed for user|Outbound delivery deferred|ModuleNotFoundError|ImportError" | tail -40'
+ssh -o BatchMode=yes root@spanreed.ink 'deadline=$((SECONDS+90)); mres=TIMEOUT; while [ $SECONDS -lt $deadline ]; do log=$(journalctl -u spanreed -S -3m --no-pager); if printf "%s" "$log" | grep -qE "ModuleNotFoundError|ImportError"; then mres=FATAL; break; fi; if printf "%s" "$log" | grep -q "Started polling"; then mres=OK; break; fi; sleep 3; done; echo "MONITOR_RESULT=$mres"; echo "SERVICE=$(systemctl is-active spanreed)"; echo "=== startup markers ==="; journalctl -u spanreed -S -3m --no-pager | grep -iE "Running [0-9]+ plugins|Started polling|Started outbound|crashed for user|Outbound delivery deferred|Flood control|ModuleNotFoundError|ImportError" | tail -40'
 ```
 
 Interpret the result — a plain `Traceback` is NOT necessarily a deploy
@@ -72,8 +72,9 @@ the deploy on:
 **Deploy succeeded when all of:**
 - `MONITOR_RESULT=OK` and `SERVICE=active`
 - `Running N plugins` appears and startup reached `Started polling`
-- `Started outbound-message consumer for user ...` (the durable-queue
-  consumers came up)
+- `Started outbound dispatcher for user ...` (the per-user send dispatchers
+  came up; before 2026-07 this marker read `Started outbound-message
+  consumer`)
 - **no** `ModuleNotFoundError` / `ImportError` — especially
   `No module named 'aiolimiter'`, which means `poetry install` didn't take.
 

--- a/src/spanreed/apis/obsidian.py
+++ b/src/spanreed/apis/obsidian.py
@@ -7,6 +7,8 @@ import datetime
 import dataclasses
 import base64
 
+from telegram import Message
+
 from spanreed.plugin import Plugin
 from spanreed.user import User
 from spanreed.storage import redis_api
@@ -29,6 +31,7 @@ class ObsidianApi:
     def __init__(self, user: User) -> None:
         self._logger = logging.getLogger(__name__)
         self._user = user
+        self._progress_message: Message | None = None
 
     @classmethod
     async def for_user(cls, user: User) -> "ObsidianApi":
@@ -59,7 +62,7 @@ class ObsidianApi:
                 self._progress_message = await bot.send_message(text, parse_html=False)
             else:
                 try:
-                    await self._progress_message.edit_text(text)
+                    await bot.edit_message_text(self._progress_message, text)
                 except Exception:
                     pass  # telegram raises if text hasn't changed
             await asyncio.sleep(3)
@@ -139,8 +142,9 @@ class ObsidianApi:
                 # Final attempt failed
                 if self._progress_message is not None:
                     try:
-                        await self._progress_message.edit_text(
-                            "❌ Obsidian didn't respond"
+                        bot = await TelegramBotApi.for_user(self._user)
+                        await bot.edit_message_text(
+                            self._progress_message, "❌ Obsidian didn't respond"
                         )
                     except Exception:
                         pass
@@ -154,7 +158,8 @@ class ObsidianApi:
         # Clean up progress message on success
         if self._progress_message is not None:
             try:
-                await self._progress_message.delete()
+                bot = await TelegramBotApi.for_user(self._user)
+                await bot.delete_message(self._progress_message)
             except Exception:
                 pass
 
@@ -171,7 +176,7 @@ class ObsidianApi:
             )
             if len(msg) > 1500:
                 msg = msg[:1500] + " …(truncated)"
-            bot: TelegramBotApi = await TelegramBotApi.for_user(self._user)
+            bot = await TelegramBotApi.for_user(self._user)
             await bot.send_message(msg)
             result: Any = response.get("result")
             if result == "file not found":

--- a/src/spanreed/apis/telegram_bot.py
+++ b/src/spanreed/apis/telegram_bot.py
@@ -12,6 +12,7 @@ from collections.abc import AsyncGenerator
 
 from spanreed.plugin import Plugin
 from spanreed.storage import redis_api
+from spanreed.apis.telegram_dispatcher import OutboundDispatcher
 from spanreed.user import User
 
 from telegram import (
@@ -20,13 +21,6 @@ from telegram import (
     InlineKeyboardMarkup,
     constants,
     Message,
-)
-from telegram.error import (
-    RetryAfter,
-    TimedOut,
-    NetworkError,
-    BadRequest,
-    Forbidden,
 )
 from telegram.ext import (
     ApplicationBuilder,
@@ -46,13 +40,13 @@ USER_INTERACTION_LOCKS = "user-interaction-locks"
 USER_INTERACTION_QUEUES = "user-interaction-queue"
 CURRENT_USER_INTERACTION = "current-user-interaction"
 USER_MESSAGE_CALLBACK_ID = "user-message-callback-id"
+OUTBOUND_DISPATCHERS = "outbound-dispatchers"
 
-# Durable outbound notification queue. `notify()` enqueues here; a per-user
-# consumer (started by TelegramBotPlugin) drains it, so notifications survive
-# restarts and Telegram flood-control bans instead of being dropped.
+# Durable outbound notification queue. `notify()` enqueues here; the per-user
+# OutboundDispatcher (see telegram_dispatcher.py) drains it as its
+# low-priority lane, so notifications survive restarts and Telegram
+# flood-control bans instead of being dropped.
 OUTBOUND_QUEUE_MAX = 200  # keep newest N; drop older on overflow
-OUTBOUND_INITIAL_BACKOFF_S = 60
-OUTBOUND_MAX_BACKOFF_S = 30 * 60
 
 
 class CallbackData(NamedTuple):
@@ -103,36 +97,28 @@ class TelegramBotPlugin(Plugin[UserConfig]):
             TelegramBotApi._application_initialized.set()
             TelegramBotApi._application = application
 
-            # Start the durable outbound-message consumer for each user so
-            # queued notifications (see TelegramBotApi.notify) get delivered.
-            await self._start_outbound_consumers()
+            # Start the per-user send dispatcher for each user so queued
+            # notifications (see TelegramBotApi.notify) get delivered.
+            await self._start_dispatchers()
 
             try:
                 # Wait for cancellation so we can perform the cleanup.
                 self._logger.info("Waiting for cancellation...")
                 while True:
-                    await asyncio.sleep(
-                        datetime.timedelta(hours=1).total_seconds()
-                    )
+                    await asyncio.sleep(datetime.timedelta(hours=1).total_seconds())
             except asyncio.CancelledError:
-                self._logger.exception(
-                    "Cancellation received. Stopping updater..."
-                )
+                self._logger.exception("Cancellation received. Stopping updater...")
                 await application.updater.stop()
                 self._logger.info("Stopping application...")
                 await application.stop()
                 self._logger.info("Stopped")
                 raise
 
-    async def _start_outbound_consumers(self) -> None:
+    async def _start_dispatchers(self) -> None:
         for user in await self.get_users():
             bot = await TelegramBotApi.for_user(user)
-            task = asyncio.create_task(bot.deliver_outbound_messages())
-            self.background_tasks.add(task)
-            task.add_done_callback(self.background_tasks.discard)
-            self._logger.info(
-                f"Started outbound-message consumer for user {user.id}"
-            )
+            await bot._get_dispatcher()
+            self._logger.info(f"Started outbound dispatcher for user {user.id}")
 
     async def setup_application(
         self,
@@ -147,17 +133,17 @@ class TelegramBotPlugin(Plugin[UserConfig]):
         application = (
             app_builder.token(os.environ["TELEGRAM_API_TOKEN"])
             .arbitrary_callback_data(True)
-            # Pace outbound requests to Telegram's limits (~1 msg/s per chat,
-            # ~30/s overall) so bursts don't trip flood control, and retry the
-            # occasional RetryAfter transparently. This prevents the multi-hour
-            # bans we'd otherwise accumulate by ignoring 429s.
-            .rate_limiter(AIORateLimiter(max_retries=3))
+            # Overall-rate safety net only (~30/s across all chats) for the
+            # rare call that doesn't go through the OutboundDispatcher.
+            # max_retries MUST stay 0: sleeping exactly `retry_after` inside
+            # the limiter synchronizes every blocked send to wake at the ban's
+            # expiry instant, re-tripping a fresh ban (the 23:01 cycle). The
+            # dispatcher owns RetryAfter handling and resumes with jitter.
+            .rate_limiter(AIORateLimiter(max_retries=0))
             .build()
         )
 
-        application.add_handler(
-            CallbackQueryHandler(self.handle_callback_query)
-        )
+        application.add_handler(CallbackQueryHandler(self.handle_callback_query))
         application.add_handler(CommandHandler("do", self.show_command_menu))
         application.add_handler(CommandHandler("start", self.start))
         application.add_handler(
@@ -191,7 +177,14 @@ class TelegramBotPlugin(Plugin[UserConfig]):
         event: asyncio.Event = context.bot_data[CALLBACK_EVENTS][cid]
         event.set()
 
-        await query.delete_message()
+        # Route the delete through the user's send dispatcher; failure just
+        # leaves the keyboard message behind, so don't let it kill the
+        # handler.
+        try:
+            bot = TelegramBotApi(callback_data.user_id)
+            await bot._dispatch("delete_choice_message", query.delete_message)
+        except Exception:
+            self._logger.exception("Failed to delete choice message")
 
     async def get_user_by_telegram_user_id(
         self, telegram_user_id: int, send_message_on_failure: bool = True
@@ -218,17 +211,13 @@ class TelegramBotPlugin(Plugin[UserConfig]):
             )
         raise KeyError(f"User not found for {telegram_user_id=}")
 
-    async def start(
-        self, update: Update, context: ContextTypes.DEFAULT_TYPE
-    ) -> None:
+    async def start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         if update.effective_user is None:
             self._logger.error("No user found in update")
             return
 
         telegram_user_id: int = update.effective_user.id
-        self._logger.info(
-            f"Got a /start command from user {telegram_user_id=}"
-        )
+        self._logger.info(f"Got a /start command from user {telegram_user_id=}")
         existing_user: Optional[User] = None
         with contextlib.suppress(KeyError):
             existing_user = await self.get_user_by_telegram_user_id(
@@ -337,9 +326,7 @@ class TelegramBotPlugin(Plugin[UserConfig]):
             )
 
             self._logger.info(f"Inside internal task for /do for {user}")
-            self._logger.info(
-                f"Current commands: {app.bot_data[PLUGIN_COMMANDS]}"
-            )
+            self._logger.info(f"Current commands: {app.bot_data[PLUGIN_COMMANDS]}")
             async with suppress_and_log_exception(BaseException):
                 bot = await TelegramBotApi.for_user(user)
 
@@ -348,26 +335,19 @@ class TelegramBotPlugin(Plugin[UserConfig]):
                     PLUGIN_COMMANDS, {}
                 ).items():
                     if plugin_canonical_name not in user.plugins:
-                        self._logger.debug(
-                            f"Skipping {plugin_canonical_name=}"
-                        )
+                        self._logger.debug(f"Skipping {plugin_canonical_name=}")
                         continue
 
-                    self._logger.info(
-                        f"Adding commands for {plugin_canonical_name=}"
-                    )
+                    self._logger.info(f"Adding commands for {plugin_canonical_name=}")
 
                     for command in commands:
                         self._logger.info(f"Adding command {command=}")
                         shown_commands.append(command)
 
-                async with bot.user_interaction(
-                    priority=UserInteractionPriority.HIGH
-                ):
+                async with bot.user_interaction(priority=UserInteractionPriority.HIGH):
                     choice = await bot.request_user_choice(
                         "Please choose a command to run:",
-                        [command.text for command in shown_commands]
-                        + ["Cancel"],
+                        [command.text for command in shown_commands] + ["Cancel"],
                     )
                     if choice == len(shown_commands):
                         return
@@ -382,9 +362,7 @@ class TelegramBotPlugin(Plugin[UserConfig]):
 
         task = asyncio.create_task(show_command_menu_task())
         self._do_tasks[telegram_user_id] = task
-        task.add_done_callback(
-            lambda _: self._do_tasks.pop(telegram_user_id, None)
-        )
+        task.add_done_callback(lambda _: self._do_tasks.pop(telegram_user_id, None))
 
     async def handle_message(
         self, update: Update, context: ContextTypes.DEFAULT_TYPE
@@ -489,9 +467,7 @@ class TelegramBotApi:
         self._preempted = False
 
     @classmethod
-    async def register_command(
-        cls, plugin: Plugin, command: PluginCommand
-    ) -> None:
+    async def register_command(cls, plugin: Plugin, command: PluginCommand) -> None:
         _logger = logging.getLogger(cls.__name__)
         _logger.info(f"Registering command '{command.text}'")
         app = await cls.get_application()
@@ -516,9 +492,7 @@ class TelegramBotApi:
         _logger.info("Application initialized")
         user_config: UserConfig = await TelegramBotPlugin.get_config(user)
         _logger.info(f"Getting TelegramBotApi for {user=} with {user_config=}")
-        return TelegramBotApi(
-            (await TelegramBotPlugin.get_config(user)).user_id
-        )
+        return TelegramBotApi((await TelegramBotPlugin.get_config(user)).user_id)
 
     @classmethod
     def set_application(cls, application: Application) -> None:
@@ -527,24 +501,62 @@ class TelegramBotApi:
         cls._application = application
         cls._application_initialized.set()
 
+    async def _get_dispatcher(self) -> OutboundDispatcher:
+        """Get (lazily creating and starting) this chat's send dispatcher.
+
+        Stored in ``bot_data`` so the many short-lived TelegramBotApi
+        instances for a user share one dispatcher, and created on first use
+        so users registered after startup get one too.
+        """
+        app = await self.get_application()
+        dispatchers: dict[int, tuple[OutboundDispatcher, asyncio.Task]] = (
+            app.bot_data.setdefault(OUTBOUND_DISPATCHERS, {})
+        )
+        entry = dispatchers.get(self._telegram_user_id)
+        if entry is None:
+            dispatcher = OutboundDispatcher(
+                chat_id=self._telegram_user_id,
+                redis=redis_api,
+                send_text=self._send_text_raw,
+            )
+            # The task reference is kept alive by the bot_data entry.
+            task = asyncio.create_task(dispatcher.run())
+            entry = (dispatcher, task)
+            dispatchers[self._telegram_user_id] = entry
+        return entry[0]
+
+    async def _dispatch(
+        self, description: str, api_call: Callable[[], Awaitable]
+    ) -> object:
+        """Run a Telegram API call through this chat's send dispatcher."""
+        dispatcher = await self._get_dispatcher()
+        return await dispatcher.enqueue(description, api_call)
+
     async def send_document(self, file_name: str, data: bytes) -> Message:
         app: Application = await self.get_application()
+
+        async def api_call() -> Message:
+            return cast(
+                Message,
+                await app.bot.send_document(
+                    chat_id=self._telegram_user_id,
+                    document=data,
+                    filename=file_name,
+                ),
+            )
+
         return cast(
-            Message,
-            await app.bot.send_document(
-                chat_id=self._telegram_user_id,
-                document=data,
-                filename=file_name,
-            ),
+            Message, await self._dispatch(f"send_document {file_name}", api_call)
         )
 
-    async def send_message(
+    async def _send_text_raw(
         self,
         text: str,
-        *,
         parse_html: bool = True,
         parse_markdown: bool = False,
     ) -> Message:
+        """The actual sendMessage API call. Only the dispatcher's own lanes
+        may call this directly; everything else goes through send_message."""
         app: Application = await self.get_application()
         parse_mode = None
         if parse_html:
@@ -560,6 +572,29 @@ class TelegramBotApi:
                     parse_mode=parse_mode,
                 ),
             )
+
+    async def send_message(
+        self,
+        text: str,
+        *,
+        parse_html: bool = True,
+        parse_markdown: bool = False,
+    ) -> Message:
+        return cast(
+            Message,
+            await self._dispatch(
+                "send_message",
+                lambda: self._send_text_raw(text, parse_html, parse_markdown),
+            ),
+        )
+
+    async def delete_message(self, message: Message) -> bool:
+        """Delete a message via the dispatcher (never call message.delete()
+        directly — Message-object methods bypass send pacing)."""
+        return cast(bool, await self._dispatch("delete_message", message.delete))
+
+    async def edit_message_text(self, message: Message, text: str) -> None:
+        await self._dispatch("edit_message_text", lambda: message.edit_text(text))
 
     def _outbound_key(self) -> str:
         return f"outbound-messages:{self._telegram_user_id}"
@@ -593,9 +628,7 @@ class TelegramBotApi:
                 "text": text,
                 "parse_html": parse_html,
                 "parse_markdown": parse_markdown,
-                "enqueued_at": datetime.datetime.now(
-                    datetime.timezone.utc
-                ).isoformat(),
+                "enqueued_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             }
         )
         key = self._outbound_key()
@@ -605,109 +638,18 @@ class TelegramBotApi:
         # newest and drops the oldest undelivered ones.
         await redis_api.ltrim(key, 0, OUTBOUND_QUEUE_MAX - 1)
 
-    async def deliver_outbound_messages(self) -> None:
-        """Drain the durable outbound queue for this user, forever.
-
-        Started once per user by TelegramBotPlugin. Reserves each message
-        into an inflight list (crash-safe), delivers it, and only then acks
-        by removing it. Backs off on transient failures (flood control,
-        timeouts, network) so a ban doesn't turn into a hammering loop, and
-        drops messages that are permanently undeliverable (bad markup, etc.)
-        so a single poison message can't wedge the queue.
-        """
-        await self._recover_inflight()
-        while True:
-            try:
-                # Reserve the oldest message (queue tail) into the inflight
-                # list atomically, so a crash mid-send can't lose it.
-                raw = await redis_api.brpoplpush(
-                    self._outbound_key(),
-                    self._outbound_inflight_key(),
-                    timeout=30,
-                )
-                if raw is None:
-                    continue
-                await self._deliver_one(raw)
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                # Never let the consumer die (e.g. a Redis blip); back off
-                # briefly and keep going.
-                self._logger.exception(
-                    "Outbound delivery loop error; retrying in 5s."
-                )
-                await asyncio.sleep(5)
-
-    async def _recover_inflight(self) -> None:
-        """Return messages reserved but not acked before a crash to the queue.
-
-        Pushes them back on the right (oldest) end so they keep FIFO priority.
-        """
-        while (
-            item := await redis_api.lpop(self._outbound_inflight_key())
-        ) is not None:
-            await redis_api.rpush(self._outbound_key(), item)
-
-    async def _deliver_one(self, raw: bytes | str) -> None:
-        """Deliver one reserved message, retrying until it sticks or is dropped."""
-        try:
-            message = json.loads(raw)
-            text = message["text"]
-            parse_html = message.get("parse_html", True)
-            parse_markdown = message.get("parse_markdown", False)
-        except (ValueError, KeyError, TypeError):
-            self._logger.exception(
-                f"Dropping malformed outbound entry: {raw!r}"
-            )
-            await redis_api.lrem(self._outbound_inflight_key(), 1, raw)
-            return
-
-        backoff = OUTBOUND_INITIAL_BACKOFF_S
-        while True:
-            try:
-                await self.send_message(
-                    text,
-                    parse_html=parse_html,
-                    parse_markdown=parse_markdown,
-                )
-            except asyncio.CancelledError:
-                raise
-            except (BadRequest, Forbidden):
-                # Permanent (bad markup, message too long, bot blocked):
-                # retrying can't help, so drop it. Caught before the transient
-                # branch because BadRequest is a subclass of NetworkError.
-                self._logger.exception(
-                    f"Dropping undeliverable outbound message: {text!r}"
-                )
-            except (RetryAfter, TimedOut, NetworkError, TimeoutError) as e:
-                # Transient: Telegram is throttling/unreachable. Wait and
-                # retry the *same* message (it stays reserved in inflight).
-                retry_after = getattr(e, "retry_after", None)
-                delay = min(retry_after or backoff, OUTBOUND_MAX_BACKOFF_S)
-                self._logger.warning(
-                    f"Outbound delivery deferred ({e!r}); retrying in {delay}s."
-                )
-                await asyncio.sleep(delay)
-                backoff = min(backoff * 2, OUTBOUND_MAX_BACKOFF_S)
-                continue
-            except Exception:
-                # Any other error (unexpected / non-Telegram): drop rather
-                # than wedge the queue.
-                self._logger.exception(
-                    f"Dropping undeliverable outbound message: {text!r}"
-                )
-            # Delivered or permanently dropped: ack by removing from inflight.
-            await redis_api.lrem(self._outbound_inflight_key(), 1, raw)
-            return
-
     async def send_multiple_messages(
         self, *text: str, delay: int = 1, parse_html: bool = True
     ) -> None:
         app: Application = await self.get_application()
-        for message in text:
+
+        async def typing_action() -> None:
             await app.bot.send_chat_action(
                 self._telegram_user_id, action=constants.ChatAction.TYPING
             )
+
+        for message in text:
+            await self._dispatch("send_chat_action", typing_action)
             await asyncio.sleep(delay)
             await self.send_message(message, parse_html=parse_html)
 
@@ -755,13 +697,19 @@ class TelegramBotApi:
                 keyboard[-1].append(button_to_append)
 
         async def send_message() -> Message:
+            async def api_call() -> Message:
+                return cast(
+                    Message,
+                    await app.bot.send_message(
+                        chat_id=self._telegram_user_id,
+                        text=prompt,
+                        reply_markup=InlineKeyboardMarkup(keyboard),
+                    ),
+                )
+
             return cast(
                 Message,
-                await app.bot.send_message(
-                    chat_id=self._telegram_user_id,
-                    text=prompt,
-                    reply_markup=InlineKeyboardMarkup(keyboard),
-                ),
+                await self._dispatch("send_choice_prompt", api_call),
             )
 
         # Wait for the user to select a choice.
@@ -814,7 +762,7 @@ class TelegramBotApi:
                         await callback_event.wait()
                         break
                 except asyncio.TimeoutError:
-                    if not await message.delete():
+                    if not await self.delete_message(message):
                         raise RuntimeError("Failed to delete message")
 
                     queues = await self._get_user_interaction_queues()
@@ -822,7 +770,7 @@ class TelegramBotApi:
                         len(queue) for queue in queues.values()
                     )
                     if pending_message is not None:
-                        await pending_message.delete()
+                        await self.delete_message(pending_message)
                     pending_message = await self.send_message(
                         f"You have {pending_interactions + 1} pending interactions, this is the first one:"
                     )
@@ -830,11 +778,15 @@ class TelegramBotApi:
         except asyncio.CancelledError:
             self._logger.info(f"Callback {callback_id} was cancelled")
             if message is not None:
-                if not await message.delete():
-                    self._logger.error("Failed to delete message")
+                # Suppress send failures (e.g. RetryAfter from the
+                # dispatcher during a ban) so they can't mask the
+                # CancelledError we must re-raise.
+                with contextlib.suppress(Exception):
+                    if not await self.delete_message(message):
+                        self._logger.error("Failed to delete message")
             raise
         if pending_message is not None:
-            await pending_message.delete()
+            await self.delete_message(pending_message)
         self._logger.info(f"Callback {callback_id} done")
         return app.bot_data[CALLBACK_EVENT_RESULTS][callback_id]  # type: ignore
 
@@ -851,9 +803,7 @@ class TelegramBotApi:
         app = await self.get_application()
         return app.bot_data.setdefault(  # type: ignore
             USER_INTERACTION_QUEUES, {}
-        ).setdefault(
-            self._telegram_user_id, self._get_default_priority_queue()
-        )
+        ).setdefault(self._telegram_user_id, self._get_default_priority_queue())
 
     async def _get_current_user_interaction(self) -> UserInteraction | None:
         app = await self.get_application()
@@ -900,9 +850,7 @@ class TelegramBotApi:
 
         for priority in UserInteractionPriority:  # high to low
             if interaction_queue[priority]:
-                user_interaction: UserInteraction = interaction_queue[
-                    priority
-                ].pop(0)
+                user_interaction: UserInteraction = interaction_queue[priority].pop(0)
                 self._logger.info(f"Allowing {user_interaction=}")
                 user_interaction.allow_to_run()
                 await self._set_current_user_interaction(user_interaction)
@@ -956,17 +904,13 @@ class TelegramBotApi:
         self, user_interaction: UserInteraction
     ) -> None:
         user_interaction_queues = await self._get_user_interaction_queues()
-        user_interaction_queues[user_interaction.priority].append(
-            user_interaction
-        )
+        user_interaction_queues[user_interaction.priority].append(user_interaction)
 
     async def _remove_from_user_interaction_queue(
         self, user_interaction: UserInteraction
     ) -> None:
         user_interaction_queues = await self._get_user_interaction_queues()
-        user_interaction_queues[user_interaction.priority].remove(
-            user_interaction
-        )
+        user_interaction_queues[user_interaction.priority].remove(user_interaction)
 
     @contextlib.asynccontextmanager
     async def user_interaction(
@@ -996,9 +940,7 @@ class TelegramBotApi:
         async with lock:
             try:
                 asyncio.create_task(
-                    self._try_to_allow_next_user_interaction(
-                        user_interaction.timeout
-                    )
+                    self._try_to_allow_next_user_interaction(user_interaction.timeout)
                 )
                 yield
             except asyncio.CancelledError:

--- a/src/spanreed/apis/telegram_bot_test.py
+++ b/src/spanreed/apis/telegram_bot_test.py
@@ -1,18 +1,18 @@
 import asyncio
-import contextlib
 import json
 import pytest
 from unittest.mock import AsyncMock, patch
 
-from telegram.error import RetryAfter, BadRequest
-
 from spanreed.apis.telegram_bot import TelegramBotApi, OUTBOUND_QUEUE_MAX
+from spanreed.test_utils import FakeRedis
 from spanreed.user import User
 
 
+@patch("spanreed.apis.telegram_bot.redis_api", new_callable=FakeRedis)
 @patch.object(TelegramBotApi, "get_application")
 def test_user_interaction_simple_usage(
     mock_get_application: AsyncMock,
+    fake_redis: FakeRedis,
 ) -> None:
     """Test using the user_interaction context manager from the user's perspective."""
 
@@ -34,7 +34,7 @@ def test_user_interaction_simple_usage(
         # Run the function
         await send_greeting()
 
-        # Verify that a message was sent
+        # Verify that a message was sent (through the send dispatcher)
         mock_app.bot.send_message.assert_called_once_with(
             chat_id=telegram_user_id, text="Hello!", parse_mode="HTML"
         )
@@ -90,12 +90,10 @@ def test_user_interaction_handles_early_cancellation_properly(
                 "spanreed.apis.telegram_bot.UserInteraction"
             ) as mock_user_interaction_class:
                 mock_user_interaction = AsyncMock()
-                mock_user_interaction_class.return_value = (
-                    mock_user_interaction
-                )
+                mock_user_interaction_class.return_value = mock_user_interaction
                 # This simulates cancellation during the queue waiting phase
-                mock_user_interaction.wait_to_run.side_effect = (
-                    asyncio.CancelledError("Test cancellation")
+                mock_user_interaction.wait_to_run.side_effect = asyncio.CancelledError(
+                    "Test cancellation"
                 )
 
                 # After the fix, this should raise CancelledError (not RuntimeError)
@@ -105,97 +103,25 @@ def test_user_interaction_handles_early_cancellation_properly(
                         await bot_api.send_message("Hello!")
 
                 # Verify that the queue cleanup was attempted before the raise
-                mock_remove_queue.assert_called_once_with(
-                    mock_user_interaction
-                )
+                mock_remove_queue.assert_called_once_with(mock_user_interaction)
 
     # Run the async test function
     asyncio.run(run_test())
 
 
 # ---------------------------------------------------------------------------
-# Durable outbound notification queue
+# Durable outbound notification queue (producer side; delivery is tested in
+# telegram_dispatcher_test.py)
 # ---------------------------------------------------------------------------
 
 OUTBOUND_USER_ID = 123
 QUEUE = f"outbound-messages:{OUTBOUND_USER_ID}"
-INFLIGHT = f"outbound-messages:inflight:{OUTBOUND_USER_ID}"
-
-
-class FakeRedis:
-    """In-memory stand-in for the Redis list ops the outbound queue uses.
-
-    Lists are modeled head-first (index 0 == left/head), matching Redis:
-    LPUSH inserts at the head, so the tail is the oldest element.
-    """
-
-    def __init__(self) -> None:
-        self.lists: dict[str, list] = {}
-
-    async def lpush(self, key: str, *values: object) -> int:
-        lst = self.lists.setdefault(key, [])
-        for value in values:
-            lst.insert(0, value)
-        return len(lst)
-
-    async def rpush(self, key: str, *values: object) -> int:
-        lst = self.lists.setdefault(key, [])
-        lst.extend(values)
-        return len(lst)
-
-    async def lpop(self, key: str) -> object | None:
-        lst = self.lists.get(key, [])
-        return lst.pop(0) if lst else None
-
-    async def ltrim(self, key: str, start: int, end: int) -> bool:
-        lst = self.lists.get(key, [])
-        self.lists[key] = lst[start : end + 1]
-        return True
-
-    async def brpoplpush(
-        self, src: str, dst: str, timeout: int = 0
-    ) -> object | None:
-        lst = self.lists.get(src, [])
-        if not lst:
-            return None
-        value = lst.pop()  # tail == oldest
-        self.lists.setdefault(dst, []).insert(0, value)
-        return value
-
-    async def lrem(self, key: str, count: int, value: object) -> int:
-        lst = self.lists.get(key, [])
-        removed = 0
-        while value in lst and (count == 0 or removed < count):
-            lst.remove(value)
-            removed += 1
-        return removed
-
-
-class FakeRedisCancelOnEmpty(FakeRedis):
-    """FakeRedis whose blocking pop raises CancelledError when the queue is
-
-    empty, so the consumer loop terminates in a test once it has drained.
-    """
-
-    async def brpoplpush(
-        self, src: str, dst: str, timeout: int = 0
-    ) -> object | None:
-        value = await super().brpoplpush(src, dst, timeout)
-        if value is None:
-            raise asyncio.CancelledError
-        return value
-
-
-def _outbound_bot(fake: FakeRedis) -> TelegramBotApi:
-    bot = TelegramBotApi(OUTBOUND_USER_ID)
-    bot.send_message = AsyncMock()  # type: ignore[method-assign]
-    return bot
 
 
 def test_notify_enqueues_and_bounds_backlog() -> None:
     fake = FakeRedis()
     with patch("spanreed.apis.telegram_bot.redis_api", new=fake):
-        bot = _outbound_bot(fake)
+        bot = TelegramBotApi(OUTBOUND_USER_ID)
 
         async def go() -> None:
             for i in range(OUTBOUND_QUEUE_MAX + 5):
@@ -207,105 +133,3 @@ def test_notify_enqueues_and_bounds_backlog() -> None:
     assert len(fake.lists[QUEUE]) == OUTBOUND_QUEUE_MAX
     newest = json.loads(fake.lists[QUEUE][0])
     assert newest["text"] == f"m{OUTBOUND_QUEUE_MAX + 4}"
-
-
-def test_deliver_one_success_acks() -> None:
-    fake = FakeRedis()
-    raw = json.dumps({"text": "hello", "parse_html": True})
-    fake.lists[INFLIGHT] = [raw]
-    with patch("spanreed.apis.telegram_bot.redis_api", new=fake):
-        bot = _outbound_bot(fake)
-        asyncio.run(bot._deliver_one(raw))
-
-    bot.send_message.assert_awaited_once_with(
-        "hello", parse_html=True, parse_markdown=False
-    )
-    assert fake.lists[INFLIGHT] == []  # acked
-
-
-def test_deliver_one_retries_transient_then_acks() -> None:
-    fake = FakeRedis()
-    raw = json.dumps({"text": "hi"})
-    fake.lists[INFLIGHT] = [raw]
-    with (
-        patch("spanreed.apis.telegram_bot.redis_api", new=fake),
-        patch("asyncio.sleep", new=AsyncMock()) as mock_sleep,
-    ):
-        bot = _outbound_bot(fake)
-        bot.send_message = AsyncMock(  # type: ignore[method-assign]
-            side_effect=[RetryAfter(2), None]
-        )
-        asyncio.run(bot._deliver_one(raw))
-
-    assert bot.send_message.await_count == 2
-    mock_sleep.assert_awaited()  # it backed off before retrying
-    assert fake.lists[INFLIGHT] == []  # eventually acked
-
-
-def test_deliver_one_drops_permanent_error() -> None:
-    fake = FakeRedis()
-    raw = json.dumps({"text": "bad markup"})
-    fake.lists[INFLIGHT] = [raw]
-    with patch("spanreed.apis.telegram_bot.redis_api", new=fake):
-        bot = _outbound_bot(fake)
-        bot.send_message = AsyncMock(  # type: ignore[method-assign]
-            side_effect=BadRequest("nope")
-        )
-        asyncio.run(bot._deliver_one(raw))
-
-    # Tried once, then dropped (removed from inflight) rather than retried.
-    bot.send_message.assert_awaited_once()
-    assert fake.lists[INFLIGHT] == []
-
-
-def test_deliver_one_drops_malformed_entry() -> None:
-    fake = FakeRedis()
-    raw = "this is not json"
-    fake.lists[INFLIGHT] = [raw]
-    with patch("spanreed.apis.telegram_bot.redis_api", new=fake):
-        bot = _outbound_bot(fake)
-        asyncio.run(bot._deliver_one(raw))
-
-    bot.send_message.assert_not_awaited()
-    assert fake.lists[INFLIGHT] == []
-
-
-def test_recover_inflight_returns_messages_to_queue_tail() -> None:
-    fake = FakeRedis()
-    fake.lists[INFLIGHT] = ["stranded"]
-    fake.lists[QUEUE] = ["newer"]  # already queued (head == newest)
-    with patch("spanreed.apis.telegram_bot.redis_api", new=fake):
-        bot = _outbound_bot(fake)
-        asyncio.run(bot._recover_inflight())
-
-    assert fake.lists[INFLIGHT] == []
-    # Recovered message goes to the tail (oldest), so it is delivered first.
-    assert fake.lists[QUEUE][-1] == "stranded"
-
-
-def test_consumer_drains_fifo_and_recovers_inflight() -> None:
-    fake = FakeRedisCancelOnEmpty()
-    # A message reserved but not acked before a crash.
-    fake.lists[INFLIGHT] = [json.dumps({"text": "stranded"})]
-
-    sent: list[str] = []
-
-    def collect(text: str, **_kwargs: object) -> None:
-        sent.append(text)
-
-    with patch("spanreed.apis.telegram_bot.redis_api", new=fake):
-        bot = _outbound_bot(fake)
-        bot.send_message = AsyncMock(side_effect=collect)  # type: ignore[method-assign]
-
-        async def go() -> None:
-            await bot.notify("a")
-            await bot.notify("b")
-            with contextlib.suppress(asyncio.CancelledError):
-                await bot.deliver_outbound_messages()
-
-        asyncio.run(go())
-
-    # Recovered message delivered first, then the queue in FIFO order.
-    assert sent == ["stranded", "a", "b"]
-    assert fake.lists.get(QUEUE, []) == []
-    assert fake.lists.get(INFLIGHT, []) == []

--- a/src/spanreed/apis/telegram_dispatcher.py
+++ b/src/spanreed/apis/telegram_dispatcher.py
@@ -1,0 +1,288 @@
+"""Per-user outbound send dispatcher for the Telegram bot.
+
+Every Telegram API call for a given chat goes through one
+:class:`OutboundDispatcher`, which paces sends to Telegram's limits and
+centralizes ``RetryAfter`` (flood control) handling. This is what prevents
+the self-perpetuating multi-hour bans we used to get: during a ban the
+dispatcher stops hitting the API entirely (interactive sends fail fast,
+durable notifications wait in Redis), and it resumes with a small random
+jitter so ban expiry never triggers a synchronized burst.
+
+Two priority lanes:
+
+- **HIGH** — an in-memory queue of :class:`SendJob`s: interactive sends,
+  keyboard prompts, edits, deletes, documents. The caller awaits the job's
+  future and gets the API result (e.g. the ``Message``) back.
+- **LOW** — the durable per-user Redis notification queue produced by
+  ``TelegramBotApi.notify()``. Entries are reserved into an inflight list
+  before sending (crash-safe) and acked after, preserving the previous
+  consumer's semantics: transient errors retry the same message with
+  backoff, permanent errors drop it so a poison message can't wedge the
+  queue.
+"""
+
+import asyncio
+import json
+import logging
+import random
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+from aiolimiter import AsyncLimiter
+
+from telegram.error import (
+    BadRequest,
+    Forbidden,
+    NetworkError,
+    RetryAfter,
+    TimedOut,
+)
+
+PER_CHAT_MIN_INTERVAL_S = 1.1
+BAN_FAIL_THRESHOLD_S = 60.0
+RESUME_JITTER_RANGE_S = (1.0, 10.0)
+IDLE_POLL_INTERVAL_S = 2.0
+LOW_INITIAL_BACKOFF_S = 60.0
+LOW_MAX_BACKOFF_S = 30.0 * 60
+
+# Shared across all dispatchers: Telegram's overall bot limit is ~30
+# messages/second; stay under it.
+_GLOBAL_LIMITER = AsyncLimiter(25, 1)
+
+
+@dataclass
+class SendJob:
+    description: str
+    run: Callable[[], Awaitable[Any]]
+    future: asyncio.Future
+
+
+class OutboundDispatcher:
+    """Paced, prioritized executor for all sends to a single chat."""
+
+    def __init__(
+        self,
+        chat_id: int,
+        redis: Any,
+        send_text: Callable[[str, bool, bool], Awaitable[Any]],
+        *,
+        per_chat_min_interval: float = PER_CHAT_MIN_INTERVAL_S,
+        global_limiter: AsyncLimiter | None = None,
+        ban_fail_threshold: float = BAN_FAIL_THRESHOLD_S,
+        resume_jitter: tuple[float, float] = RESUME_JITTER_RANGE_S,
+        idle_poll_interval: float = IDLE_POLL_INTERVAL_S,
+    ) -> None:
+        self._chat_id = chat_id
+        self._redis = redis
+        # Sends a plain notification text: (text, parse_html, parse_markdown).
+        # Injected so this module stays independent of the bot wiring.
+        self._send_text = send_text
+        self._per_chat_min_interval = per_chat_min_interval
+        self._global_limiter = (
+            global_limiter if global_limiter is not None else _GLOBAL_LIMITER
+        )
+        self._ban_fail_threshold = ban_fail_threshold
+        self._resume_jitter = resume_jitter
+        self._idle_poll_interval = idle_poll_interval
+
+        self._logger = logging.getLogger(f"{__name__}.OutboundDispatcher.{chat_id}")
+        self._high: asyncio.Queue[SendJob] = asyncio.Queue()
+        # A LOW entry reserved from Redis but not yet delivered/acked.
+        self._pending_low: bytes | str | None = None
+        self._low_backoff = LOW_INITIAL_BACKOFF_S
+        self._last_send_at: float | None = None
+        self._paused_until: float | None = None
+        # While banned (a RetryAfter longer than the threshold), HIGH jobs
+        # fail fast instead of queueing so interactive callers don't hang for
+        # hours holding the user-interaction lock.
+        self._banned = False
+
+    def _outbound_key(self) -> str:
+        return f"outbound-messages:{self._chat_id}"
+
+    def _inflight_key(self) -> str:
+        return f"outbound-messages:inflight:{self._chat_id}"
+
+    @staticmethod
+    def _now() -> float:
+        return asyncio.get_running_loop().time()
+
+    def _remaining_pause(self) -> float:
+        if self._paused_until is None:
+            return 0.0
+        return max(0.0, self._paused_until - self._now())
+
+    async def enqueue(self, description: str, run: Callable[[], Awaitable[Any]]) -> Any:
+        """Submit a HIGH-priority job and wait for its result.
+
+        Raises ``RetryAfter`` immediately when the dispatcher is in a ban
+        pause, with the remaining pause time.
+        """
+        if self._banned and self._remaining_pause() > 0:
+            raise RetryAfter(int(self._remaining_pause()) + 1)
+        job = SendJob(
+            description=description,
+            run=run,
+            future=asyncio.get_running_loop().create_future(),
+        )
+        await self._high.put(job)
+        return await job.future
+
+    async def run(self) -> None:
+        """Process jobs forever. Started once per user as a background task."""
+        await self._recover_inflight()
+        while True:
+            try:
+                await self._process_next()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # Defensive: never let the dispatcher die (e.g. a Redis
+                # blip); everything for this chat depends on it.
+                self._logger.exception("Dispatcher loop error; retrying in 5s.")
+                await asyncio.sleep(5)
+
+    async def _recover_inflight(self) -> None:
+        """Return messages reserved but not acked before a crash to the queue.
+
+        Pushes them back on the right (oldest) end so they keep FIFO priority.
+        """
+        while (item := await self._redis.lpop(self._inflight_key())) is not None:
+            await self._redis.rpush(self._outbound_key(), item)
+
+    async def _process_next(self) -> None:
+        """Process a single job (or idle briefly when there's nothing to do)."""
+        await self._wait_out_pause()
+
+        if not self._high.empty():
+            await self._execute_high(self._high.get_nowait())
+            return
+
+        if self._pending_low is None:
+            self._pending_low = await self._redis.rpoplpush(
+                self._outbound_key(), self._inflight_key()
+            )
+        if self._pending_low is not None:
+            await self._deliver_low(self._pending_low)
+            return
+
+        # Nothing to do: block on the HIGH queue briefly, then loop so we
+        # also notice new LOW entries in Redis.
+        try:
+            job = await asyncio.wait_for(
+                self._high.get(), timeout=self._idle_poll_interval
+            )
+        except asyncio.TimeoutError:
+            return
+        await self._wait_out_pause()
+        await self._execute_high(job)
+
+    async def _wait_out_pause(self) -> None:
+        remaining = self._remaining_pause()
+        if remaining > 0:
+            self._logger.info(f"Paused for another {remaining:.0f}s.")
+            await asyncio.sleep(remaining)
+        self._paused_until = None
+        self._banned = False
+
+    async def _pace(self) -> None:
+        if self._last_send_at is not None:
+            wait = self._per_chat_min_interval - (self._now() - self._last_send_at)
+            if wait > 0:
+                await asyncio.sleep(wait)
+        async with self._global_limiter:
+            self._last_send_at = self._now()
+
+    def _enter_pause(self, retry_after: float) -> None:
+        jitter = random.uniform(*self._resume_jitter)
+        self._paused_until = self._now() + retry_after + jitter
+        self._logger.warning(
+            f"Flood control: pausing sends for {retry_after:.0f}s (+{jitter:.1f}s jitter)."
+        )
+        if retry_after > self._ban_fail_threshold:
+            self._banned = True
+            self._fail_queued_high(retry_after)
+
+    def _fail_queued_high(self, retry_after: float) -> None:
+        """Fail all queued HIGH jobs so interactive callers don't hang."""
+        failed = 0
+        while not self._high.empty():
+            job = self._high.get_nowait()
+            if not job.future.done():
+                job.future.set_exception(RetryAfter(int(retry_after)))
+            failed += 1
+        if failed:
+            self._logger.warning(
+                f"Failed {failed} queued interactive send(s) due to flood-control ban."
+            )
+
+    async def _execute_high(self, job: SendJob) -> None:
+        if job.future.done():  # e.g. failed while banned, or caller gone
+            return
+        while True:
+            await self._pace()
+            try:
+                result = await job.run()
+            except RetryAfter as e:
+                self._enter_pause(e.retry_after)
+                if self._banned:
+                    if not job.future.done():
+                        job.future.set_exception(e)
+                    return
+                # Short throttle: wait it out and retry the same job.
+                await self._wait_out_pause()
+                continue
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                job.future.set_exception(e)
+                return
+            job.future.set_result(result)
+            return
+
+    async def _deliver_low(self, raw: bytes | str) -> None:
+        """Deliver one reserved LOW entry; ack on success or permanent drop."""
+        try:
+            message = json.loads(raw)
+            text = message["text"]
+            parse_html = message.get("parse_html", True)
+            parse_markdown = message.get("parse_markdown", False)
+        except (ValueError, KeyError, TypeError):
+            self._logger.exception(f"Dropping malformed outbound entry: {raw!r}")
+            await self._ack_low(raw)
+            return
+
+        try:
+            await self._pace()
+            await self._send_text(text, parse_html, parse_markdown)
+        except asyncio.CancelledError:
+            raise
+        except RetryAfter as e:
+            # Keep the entry reserved; the pause delays the next attempt.
+            self._enter_pause(e.retry_after)
+            return
+        except (BadRequest, Forbidden):
+            # Permanent (bad markup, message too long, bot blocked):
+            # retrying can't help, so drop it. Caught before the transient
+            # branch because BadRequest is a subclass of NetworkError.
+            self._logger.exception(f"Dropping undeliverable outbound message: {text!r}")
+        except (TimedOut, NetworkError, TimeoutError) as e:
+            # Transient: Telegram is unreachable. Keep the entry reserved and
+            # back off exponentially before the next attempt.
+            self._logger.warning(
+                f"Outbound delivery deferred ({e!r}); retrying in {self._low_backoff:.0f}s."
+            )
+            self._paused_until = self._now() + self._low_backoff
+            self._low_backoff = min(self._low_backoff * 2, LOW_MAX_BACKOFF_S)
+            return
+        except Exception:
+            # Any other error (unexpected / non-Telegram): drop rather than
+            # wedge the queue.
+            self._logger.exception(f"Dropping undeliverable outbound message: {text!r}")
+        # Delivered or permanently dropped.
+        self._low_backoff = LOW_INITIAL_BACKOFF_S
+        await self._ack_low(raw)
+
+    async def _ack_low(self, raw: bytes | str) -> None:
+        await self._redis.lrem(self._inflight_key(), 1, raw)
+        self._pending_low = None

--- a/src/spanreed/apis/telegram_dispatcher_test.py
+++ b/src/spanreed/apis/telegram_dispatcher_test.py
@@ -1,0 +1,281 @@
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from aiolimiter import AsyncLimiter
+from telegram.error import BadRequest, RetryAfter, TimedOut
+
+from spanreed.apis.telegram_dispatcher import OutboundDispatcher
+from spanreed.test_utils import FakeRedis
+
+CHAT_ID = 123
+QUEUE = f"outbound-messages:{CHAT_ID}"
+INFLIGHT = f"outbound-messages:inflight:{CHAT_ID}"
+
+
+def make_dispatcher(
+    fake: FakeRedis,
+    send_text: AsyncMock | None = None,
+    **kwargs: Any,
+) -> OutboundDispatcher:
+    kwargs.setdefault("per_chat_min_interval", 0.0)
+    kwargs.setdefault("resume_jitter", (0.0, 0.0))
+    kwargs.setdefault("idle_poll_interval", 0.01)
+    kwargs.setdefault("global_limiter", AsyncLimiter(10_000, 1))
+    return OutboundDispatcher(
+        chat_id=CHAT_ID,
+        redis=fake,
+        send_text=send_text if send_text is not None else AsyncMock(),
+        **kwargs,
+    )
+
+
+def test_high_job_result_propagates() -> None:
+    async def go() -> None:
+        dispatcher = make_dispatcher(FakeRedis())
+        api_call = AsyncMock(return_value="the-message")
+        caller = asyncio.create_task(dispatcher.enqueue("send", api_call))
+        await asyncio.sleep(0)  # let the caller enqueue the job
+
+        await dispatcher._process_next()
+
+        assert await caller == "the-message"
+        api_call.assert_awaited_once()
+
+    asyncio.run(go())
+
+
+def test_high_job_exception_propagates() -> None:
+    async def go() -> None:
+        dispatcher = make_dispatcher(FakeRedis())
+        api_call = AsyncMock(side_effect=ValueError("boom"))
+        caller = asyncio.create_task(dispatcher.enqueue("send", api_call))
+        await asyncio.sleep(0)
+
+        await dispatcher._process_next()
+
+        with pytest.raises(ValueError):
+            await caller
+
+    asyncio.run(go())
+
+
+def test_high_executes_before_low() -> None:
+    async def go() -> None:
+        fake = FakeRedis()
+        order: list[str] = []
+
+        async def send_text(text: str, *_args: Any) -> None:
+            order.append(f"low:{text}")
+
+        dispatcher = make_dispatcher(fake, send_text=AsyncMock(side_effect=send_text))
+        await fake.lpush(QUEUE, json.dumps({"text": "notification"}))
+
+        async def high_call() -> None:
+            order.append("high")
+
+        caller = asyncio.create_task(dispatcher.enqueue("send", high_call))
+        await asyncio.sleep(0)
+
+        await dispatcher._process_next()  # HIGH takes priority
+        await dispatcher._process_next()  # then the LOW entry
+
+        await caller
+        assert order == ["high", "low:notification"]
+
+    asyncio.run(go())
+
+
+def test_pacing_spaces_out_sends() -> None:
+    async def go() -> None:
+        interval = 0.05
+        dispatcher = make_dispatcher(FakeRedis(), per_chat_min_interval=interval)
+        send_times: list[float] = []
+
+        async def api_call() -> None:
+            send_times.append(asyncio.get_running_loop().time())
+
+        callers = [
+            asyncio.create_task(dispatcher.enqueue("send", api_call)) for _ in range(2)
+        ]
+        await asyncio.sleep(0)
+
+        await dispatcher._process_next()
+        await dispatcher._process_next()
+        for caller in callers:
+            await caller
+
+        assert len(send_times) == 2
+        # Allow a little slack for event-loop timer resolution.
+        assert send_times[1] - send_times[0] >= interval * 0.9
+
+    asyncio.run(go())
+
+
+def test_short_retry_after_retries_same_job() -> None:
+    async def go() -> None:
+        dispatcher = make_dispatcher(FakeRedis())
+        api_call = AsyncMock(side_effect=[RetryAfter(0), "ok"])
+        caller = asyncio.create_task(dispatcher.enqueue("send", api_call))
+        await asyncio.sleep(0)
+
+        await dispatcher._process_next()
+
+        assert await caller == "ok"
+        assert api_call.await_count == 2
+
+    asyncio.run(go())
+
+
+def test_long_retry_after_fails_high_fast() -> None:
+    async def go() -> None:
+        dispatcher = make_dispatcher(FakeRedis(), ban_fail_threshold=60)
+        banned_call = AsyncMock(side_effect=RetryAfter(9999))
+        queued_call = AsyncMock()
+        caller1 = asyncio.create_task(dispatcher.enqueue("a", banned_call))
+        await asyncio.sleep(0)
+        caller2 = asyncio.create_task(dispatcher.enqueue("b", queued_call))
+        await asyncio.sleep(0)
+
+        await dispatcher._process_next()
+
+        # The job that hit the ban and the one queued behind it both fail.
+        with pytest.raises(RetryAfter):
+            await caller1
+        with pytest.raises(RetryAfter):
+            await caller2
+        queued_call.assert_not_awaited()
+
+        # New jobs fail immediately while the ban pause is active.
+        with pytest.raises(RetryAfter):
+            await dispatcher.enqueue("c", AsyncMock())
+
+    asyncio.run(go())
+
+
+def test_low_delivered_and_acked() -> None:
+    async def go() -> None:
+        fake = FakeRedis()
+        send_text = AsyncMock()
+        dispatcher = make_dispatcher(fake, send_text=send_text)
+        await fake.lpush(QUEUE, json.dumps({"text": "hello", "parse_html": True}))
+
+        await dispatcher._process_next()
+
+        send_text.assert_awaited_once_with("hello", True, False)
+        assert fake.lists.get(QUEUE, []) == []
+        assert fake.lists.get(INFLIGHT, []) == []
+
+    asyncio.run(go())
+
+
+def test_low_drains_fifo() -> None:
+    async def go() -> None:
+        fake = FakeRedis()
+        sent: list[str] = []
+
+        async def collect(text: str, *_args: Any) -> None:
+            sent.append(text)
+
+        dispatcher = make_dispatcher(fake, send_text=AsyncMock(side_effect=collect))
+        await fake.lpush(QUEUE, json.dumps({"text": "a"}))
+        await fake.lpush(QUEUE, json.dumps({"text": "b"}))
+
+        await dispatcher._process_next()
+        await dispatcher._process_next()
+
+        assert sent == ["a", "b"]
+
+    asyncio.run(go())
+
+
+def test_low_permanent_error_dropped_and_acked() -> None:
+    async def go() -> None:
+        fake = FakeRedis()
+        send_text = AsyncMock(side_effect=BadRequest("nope"))
+        dispatcher = make_dispatcher(fake, send_text=send_text)
+        await fake.lpush(QUEUE, json.dumps({"text": "bad markup"}))
+
+        await dispatcher._process_next()
+
+        send_text.assert_awaited_once()
+        assert fake.lists.get(QUEUE, []) == []
+        assert fake.lists.get(INFLIGHT, []) == []  # acked (dropped)
+
+    asyncio.run(go())
+
+
+def test_low_malformed_entry_dropped() -> None:
+    async def go() -> None:
+        fake = FakeRedis()
+        send_text = AsyncMock()
+        dispatcher = make_dispatcher(fake, send_text=send_text)
+        await fake.lpush(QUEUE, "this is not json")
+
+        await dispatcher._process_next()
+
+        send_text.assert_not_awaited()
+        assert fake.lists.get(INFLIGHT, []) == []
+
+    asyncio.run(go())
+
+
+def test_low_transient_error_keeps_entry_and_retries() -> None:
+    async def go() -> None:
+        fake = FakeRedis()
+        raw = json.dumps({"text": "hi"})
+        send_text = AsyncMock(side_effect=[TimedOut(), None])
+        dispatcher = make_dispatcher(fake, send_text=send_text)
+        await fake.lpush(QUEUE, raw)
+
+        await dispatcher._process_next()
+
+        # Still reserved (not acked) and the dispatcher backed off.
+        assert fake.lists[INFLIGHT] == [raw]
+        assert dispatcher._remaining_pause() > 0
+
+        # Skip the backoff and retry: the same message is delivered.
+        dispatcher._paused_until = None
+        await dispatcher._process_next()
+
+        assert send_text.await_count == 2
+        assert fake.lists.get(INFLIGHT, []) == []
+
+    asyncio.run(go())
+
+
+def test_low_long_retry_after_keeps_entry_and_bans_high() -> None:
+    async def go() -> None:
+        fake = FakeRedis()
+        raw = json.dumps({"text": "hi"})
+        send_text = AsyncMock(side_effect=RetryAfter(9999))
+        dispatcher = make_dispatcher(fake, send_text=send_text)
+        await fake.lpush(QUEUE, raw)
+
+        await dispatcher._process_next()
+
+        # The durable entry survives the ban...
+        assert fake.lists[INFLIGHT] == [raw]
+        # ...but interactive sends fail fast while it lasts.
+        with pytest.raises(RetryAfter):
+            await dispatcher.enqueue("send", AsyncMock())
+
+    asyncio.run(go())
+
+
+def test_recover_inflight_returns_messages_to_queue_tail() -> None:
+    async def go() -> None:
+        fake = FakeRedis()
+        fake.lists[INFLIGHT] = ["stranded"]
+        fake.lists[QUEUE] = ["newer"]  # already queued (head == newest)
+        dispatcher = make_dispatcher(fake)
+
+        await dispatcher._recover_inflight()
+
+        assert fake.lists[INFLIGHT] == []
+        # Recovered message goes to the tail (oldest), so it is delivered first.
+        assert fake.lists[QUEUE][-1] == "stranded"
+
+    asyncio.run(go())

--- a/src/spanreed/plugins/spanreed_monitor.py
+++ b/src/spanreed/plugins/spanreed_monitor.py
@@ -46,9 +46,7 @@ class SpanreedMonitorPlugin(Plugin):
             while True:
                 with suppress(asyncio.TimeoutError, redis.ConnectionError):
                     async with asyncio.timeout(interval.total_seconds()):
-                        _, exception = await redis_api.blpop(
-                            self.EXCEPTION_QUEUE_NAME
-                        )
+                        _, exception = await redis_api.blpop(self.EXCEPTION_QUEUE_NAME)
                         await bot.notify(
                             f"Exception retrieved from storage:\n\n"
                             f"```python\n{str(exception.decode('utf-8'))}\n```",
@@ -60,10 +58,13 @@ class SpanreedMonitorPlugin(Plugin):
         except asyncio.CancelledError:
             self._logger.info("Spanreed Monitor cancelled.")
             # Best-effort immediate send: the process (and the outbound
-            # consumer) is going away, so a queued message wouldn't be
-            # delivered until the next startup.
+            # dispatcher) is going away, so a queued message wouldn't be
+            # delivered until the next startup. The timeout covers the case
+            # where the dispatcher task was already cancelled and the send
+            # would otherwise wait forever.
             with suppress(Exception):
-                await bot.send_message("Spanreed is shutting down.")
+                async with asyncio.timeout(5):
+                    await bot.send_message("Spanreed is shutting down.")
 
     async def _monitor_obsidian_plugin(self, user: User) -> None:
         from spanreed.apis.obsidian import ObsidianPlugin
@@ -93,8 +94,7 @@ class SpanreedMonitorPlugin(Plugin):
             )
             if (
                 time_since_last_watchdog > base_timeout
-                and time_since_last_watchdog_message
-                > datetime.timedelta(minutes=30)
+                and time_since_last_watchdog_message > datetime.timedelta(minutes=30)
             ):
                 await bot.send_message("Obsidian plugin watchdog timeout.")
                 last_watchdog_message = datetime.datetime.now()
@@ -103,41 +103,32 @@ class SpanreedMonitorPlugin(Plugin):
                 timeout -= time_since_last_watchdog
 
             with suppress(asyncio.TimeoutError):
-                self._logger.debug(f"Waiting for event on {queue_name} with timeout {timeout}")
+                self._logger.debug(
+                    f"Waiting for event on {queue_name} with timeout {timeout}"
+                )
                 async with asyncio.timeout(timeout.total_seconds()):
                     _, event_json = await redis_api.blpop(
                         queue_name,
                     )
                     event = json.loads(event_json)
-                    self._logger.info(
-                        f"Obsidian plugin event received: {event}"
-                    )
+                    self._logger.info(f"Obsidian plugin event received: {event}")
                     if event["kind"] == "error":
                         self._logger.info(f"Obsidian plugin error: {event}")
-                        if (
-                            event["message"]
-                            in self.OBSIDIAN_PLUGIN_ERROR_IGNORE_LIST
-                        ):
+                        if event["message"] in self.OBSIDIAN_PLUGIN_ERROR_IGNORE_LIST:
                             continue
                         time_since_last_obsidian_error_message = (
-                            datetime.datetime.now()
-                            - last_obsidian_error_message
+                            datetime.datetime.now() - last_obsidian_error_message
                         )
-                        if (
-                            time_since_last_obsidian_error_message
-                            > datetime.timedelta(minutes=30)
+                        if time_since_last_obsidian_error_message > datetime.timedelta(
+                            minutes=30
                         ):
                             await redis_api.lpush(
                                 self.EXCEPTION_QUEUE_NAME,
                                 f"Obsidian plugin error: {event}",
                             )
-                            last_obsidian_error_message = (
-                                datetime.datetime.now()
-                            )
+                            last_obsidian_error_message = datetime.datetime.now()
                     elif event["kind"] == "watchdog":
-                        self._logger.debug(
-                            "Obsidian plugin watchdog event received."
-                        )
+                        self._logger.debug("Obsidian plugin watchdog event received.")
                         time_since_last_watchdog = datetime.timedelta()
                         last_watchdog_message = datetime.datetime.now()
 
@@ -170,12 +161,8 @@ async def suppress_and_log_exception(
             did_suppress.set(False)
             raise
         did_suppress.set(True)
-        exception_str = "".join(
-            traceback.format_exception(type(e), e, None, limit=3)
-        )
+        exception_str = "".join(traceback.format_exception(type(e), e, None, limit=3))
         logger.exception(f"Suppressed exception")
-        await redis_api.lpush(
-            SpanreedMonitorPlugin.EXCEPTION_QUEUE_NAME, exception_str
-        )
+        await redis_api.lpush(SpanreedMonitorPlugin.EXCEPTION_QUEUE_NAME, exception_str)
     else:
         did_suppress.set(False)

--- a/src/spanreed/test_utils.py
+++ b/src/spanreed/test_utils.py
@@ -37,9 +37,7 @@ class EndPluginRun(Exception):
 
 
 class AsyncContextManager:
-    async def __aenter__(
-        self, *args: Any, **kwargs: Any
-    ) -> "AsyncContextManager":
+    async def __aenter__(self, *args: Any, **kwargs: Any) -> "AsyncContextManager":
         return self
 
     async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
@@ -53,9 +51,7 @@ def patch_telegram_bot(
         f: Callable[..., None],
     ) -> Callable[..., None]:
         def f_with_patched_telegram_bot(*args: list, **kwargs: dict) -> Any:
-            with patch(
-                f"{target_package}.TelegramBotApi", autospec=True
-            ) as mock_bot:
+            with patch(f"{target_package}.TelegramBotApi", autospec=True) as mock_bot:
                 mock_bot.for_user = AsyncMock(return_value=mock_bot)
 
                 mock_bot.user_interaction = MagicMock(AsyncContextManager())
@@ -79,9 +75,7 @@ def patch_obsidian(
         f: Callable[..., None],
     ) -> Callable[..., None]:
         def f_with_patched_obsidian(*args: list, **kwargs: dict) -> Any:
-            with patch(
-                f"{target_package}.ObsidianApi", autospec=True
-            ) as mock_obsidian:
+            with patch(f"{target_package}.ObsidianApi", autospec=True) as mock_obsidian:
                 mock_obsidian.for_user = AsyncMock(return_value=mock_obsidian)
 
                 mock_obsidian.safe_generate_today_note = AsyncMock()
@@ -103,6 +97,56 @@ def patch_obsidian(
         return f_with_patched_obsidian
 
     return patch_obsidian_in_target_package
+
+
+class FakeRedis:
+    """In-memory stand-in for the Redis list ops the outbound queues use.
+
+    Lists are modeled head-first (index 0 == left/head), matching Redis:
+    LPUSH inserts at the head, so the tail is the oldest element.
+    """
+
+    def __init__(self) -> None:
+        self.lists: dict[str, list] = {}
+
+    async def lpush(self, key: str, *values: Any) -> int:
+        lst = self.lists.setdefault(key, [])
+        for value in values:
+            lst.insert(0, value)
+        return len(lst)
+
+    async def rpush(self, key: str, *values: Any) -> int:
+        lst = self.lists.setdefault(key, [])
+        lst.extend(values)
+        return len(lst)
+
+    async def lpop(self, key: str) -> Any | None:
+        lst = self.lists.get(key, [])
+        return lst.pop(0) if lst else None
+
+    async def ltrim(self, key: str, start: int, end: int) -> bool:
+        lst = self.lists.get(key, [])
+        self.lists[key] = lst[start : end + 1]
+        return True
+
+    async def rpoplpush(self, src: str, dst: str) -> Any | None:
+        lst = self.lists.get(src, [])
+        if not lst:
+            return None
+        value = lst.pop()  # tail == oldest
+        self.lists.setdefault(dst, []).insert(0, value)
+        return value
+
+    async def brpoplpush(self, src: str, dst: str, timeout: int = 0) -> Any | None:
+        return await self.rpoplpush(src, dst)
+
+    async def lrem(self, key: str, count: int, value: Any) -> int:
+        lst = self.lists.get(key, [])
+        removed = 0
+        while value in lst and (count == 0 or removed < count):
+            lst.remove(value)
+            removed += 1
+        return removed
 
 
 async def async_return_false(*_args: Any, **_kwargs: Any) -> bool:


### PR DESCRIPTION
## Problem

The bot token has been stuck in a **self-perpetuating 24h flood ban**. Log analysis showed the ban expiring at exactly 23:01:03 (Jul 13) and 23:01:04 (Jul 14): every send that failed during the day slept exactly `retry_after` inside `AIORateLimiter(max_retries=3)`, so they all woke **simultaneously at the expiry instant** — a synchronized burst that immediately re-tripped a fresh 24h ban. Private chats also had no per-chat pacing (AIORateLimiter only paces overall + group limits), and API calls were scattered across many call sites.

## Fix

New `OutboundDispatcher` (`apis/telegram_dispatcher.py`) — one per user, owning **every** Telegram API call for that chat:

- **HIGH lane** (in-memory queue): interactive sends, keyboard prompts, edits, deletes, documents, typing actions. Callers await the actual API result, so the public `TelegramBotApi` behavior is unchanged.
- **LOW lane**: the existing durable Redis notification queue from `notify()` — same entry format (pending prod notifications survive this deploy), same inflight-reservation crash-safety, same drop/retry semantics.
- **Pacing**: ≥1.1s between sends per chat + shared 25/s global limiter.
- **Centralized `RetryAfter` handling**: short throttles transparently retry the same job. A long one (>60s = a real ban) fails interactive sends fast — plugin supervisors' hourly retries then fail *locally without touching the API*, so the ban can actually expire — and the dispatcher resumes with 1–10s jitter so expiry never triggers a burst.

`telegram_bot.py` routes all its call sites through the dispatcher; `AIORateLimiter` stays only as an overall-rate safety net with `max_retries=0` (its sleep-and-retry was the herd mechanism). `message.edit_text/.delete()` call sites (Obsidian progress bar, keyboard cleanup) now go through new `bot.edit_message_text`/`bot.delete_message` helpers so they're paced too.

## Testing

- 13 new tests in `telegram_dispatcher_test.py`: priority ordering, pacing intervals, result/exception propagation, short-throttle retry, long-ban fail-fast (queued + newly enqueued jobs), LOW FIFO/ack/drop-on-permanent/retain-on-transient/inflight recovery.
- Old consumer tests ported; `FakeRedis` moved to `test_utils.py`. Full suite 102/102 green; mypy + black clean.
- Real-world verification happens post-deploy: watch overnight logs for the absence of a new ban at 23:01.

## Notes for review

- The deploy skill's startup-marker grep was updated (`Started outbound dispatcher` replaces `Started outbound-message consumer`).
- Dispatchers are created lazily on first use (covers users registered after startup) and pre-started for known users at boot.
- Fixed two pre-existing mypy errors in `obsidian.py` surfaced by the type-check (`_progress_message` was untyped).
