### PR TITLE
Silence audible library DEBUG logging

### DIFF
--- a/src/spanreed/__main__.py
+++ b/src/spanreed/__main__.py
@@ -36,6 +36,9 @@ def setup_logger() -> None:
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("httpcore").setLevel(logging.WARNING)
     logging.getLogger("telegram.ext").setLevel(logging.WARNING)
+    # The audible library logs entire API response bodies at DEBUG
+    # (~hundreds of KB per library fetch, which book-progress does hourly).
+    logging.getLogger("audible").setLevel(logging.WARNING)
 
 
 def load_plugins() -> List[Plugin]:


### PR DESCRIPTION
The root logger runs at DEBUG and only httpx/httpcore/telegram.ext were silenced. The `audible` package logs entire API response bodies at DEBUG — a single library fetch dumped ~288KB of JSON into the journal (observed in prod 2026-07-15 09:10), and the book-progress plugin fetches hourly. Set the `audible` parent logger (covers `audible.client` etc.) to WARNING alongside the existing ones.