### PR TITLE
Telegram: answer stale-keyboard presses instead of crashing

### DIFF
--- a/src/spanreed/apis/telegram_bot.py
+++ b/src/spanreed/apis/telegram_bot.py
@@ -27,6 +27,7 @@ from telegram.ext import (
     AIORateLimiter,
     ContextTypes,
     CommandHandler,
+    InvalidCallbackData,
     MessageHandler,
     CallbackQueryHandler,
     Application,
@@ -162,6 +163,17 @@ class TelegramBotPlugin(Plugin[UserConfig]):
             return
 
         self._logger.info(f"query.data={query.data}")
+        if isinstance(query.data, InvalidCallbackData):
+            # A button from before the last restart: the arbitrary-callback-
+            # data cache is in-memory, so stale keyboards can't be resolved.
+            self._logger.info("Ignoring callback from a stale keyboard")
+            with contextlib.suppress(Exception):
+                await query.answer(
+                    "This button has expired — please re-run the command.",
+                    show_alert=True,
+                )
+            return
+
         callback_data: CallbackData = cast(CallbackData, query.data)
         cid = callback_data.callback_id
 

--- a/src/spanreed/apis/telegram_bot_test.py
+++ b/src/spanreed/apis/telegram_bot_test.py
@@ -1,11 +1,36 @@
 import asyncio
 import json
 import pytest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from spanreed.apis.telegram_bot import TelegramBotApi, OUTBOUND_QUEUE_MAX
+from telegram.ext import InvalidCallbackData
+
+from spanreed.apis.telegram_bot import (
+    TelegramBotApi,
+    TelegramBotPlugin,
+    OUTBOUND_QUEUE_MAX,
+)
+from spanreed.plugin import Plugin
 from spanreed.test_utils import FakeRedis
 from spanreed.user import User
+
+
+def test_stale_callback_data_answered_not_crashed() -> None:
+    """A button press from a pre-restart keyboard yields InvalidCallbackData;
+    the handler must answer the query instead of raising AttributeError."""
+    Plugin.reset_registry()
+    plugin = TelegramBotPlugin()
+
+    update = MagicMock()
+    query = AsyncMock()
+    query.data = InvalidCallbackData()
+    update.callback_query = query
+    context = MagicMock()
+
+    asyncio.run(plugin.handle_callback_query(update, context))
+
+    query.answer.assert_awaited_once()
+    query.delete_message.assert_not_called()
 
 
 @patch("spanreed.apis.telegram_bot.redis_api", new_callable=FakeRedis)


### PR DESCRIPTION
Inline-keyboard buttons from before a service restart can't be resolved (PTB's arbitrary-callback-data cache is in-memory), so `query.data` arrives as `InvalidCallbackData` and `handle_callback_query` crashed with `AttributeError: 'InvalidCallbackData' object has no attribute 'callback_id'` (seen in prod logs 2026-07-14 16:52:46). Detect it, answer the callback query with a *this button has expired* alert, and return. Includes a regression test.